### PR TITLE
Make ActionBarSherlock#handleNative() accept any ActionBarHandler<android.app.ActionBar>

### DIFF
--- a/src/com/jakewharton/android/actionbarsherlock/ActionBarSherlock.java
+++ b/src/com/jakewharton/android/actionbarsherlock/ActionBarSherlock.java
@@ -168,7 +168,7 @@ public final class ActionBarSherlock {
 	/**
 	 * The class which will handle the native action bar.
 	 */
-	private Class<? extends NativeActionBarHandler> mNativeHandler;
+	private Class<? extends ActionBarHandler<android.app.ActionBar>> mNativeHandler;
 	
 	/**
 	 * The class which will handle a custom action bar.
@@ -372,7 +372,7 @@ public final class ActionBarSherlock {
 	 *                this declaration
 	 * @return Current instance for builder pattern.
 	 */
-	public ActionBarSherlock handleNative(Class<? extends NativeActionBarHandler> handler) {
+	public ActionBarSherlock handleNative(Class<? extends ActionBarHandler<android.app.ActionBar>> handler) {
 		assert this.mAttached == false : ERROR_ATTACHED;
 		assert this.mNativeHandler == null : ERROR_HANDLER_NATIVE;
 		assert handler != null : ERROR_HANDLER_NATIVE_NULL;


### PR DESCRIPTION
Fix issue #17: ActionBarSherlock#handleNative() doesn't accept custom ActionBarHandlers

Hi Jake,

Thanks for your work on ActionBarSherlock.  Here's my change to address issue #17 I just filed.  Hope its helpful.

Thanks,
Pete Doyle
