### PR TITLE
Reduce the number of items in the action bar when using tab navigation

### DIFF
--- a/library/src/com/actionbarsherlock/internal/app/ActionBarSupportImpl.java
+++ b/library/src/com/actionbarsherlock/internal/app/ActionBarSupportImpl.java
@@ -54,6 +54,9 @@ public final class ActionBarSupportImpl extends ActionBar {
 	
 	/** Maximum action bar items in portrait mode. */
 	private static final int MAX_ACTION_BAR_ITEMS_PORTRAIT = 3;
+
+	/** Maximum action bar items in portrait mode with tab navigation. */
+	private static final int MAX_ACTION_BAR_ITEMS_PORTRAIT_TABS = 1;
 	
 	/** Maximum action bar items in landscape mode. */
 	private static final int MAX_ACTION_BAR_ITEMS_LANDSCAPE = 4;
@@ -134,6 +137,11 @@ public final class ActionBarSupportImpl extends ActionBar {
 	
 	public void onMenuInflated(Menu menu) {
 		int maxItems = MAX_ACTION_BAR_ITEMS_PORTRAIT;
+		
+		if(getNavigationMode() == ActionBar.NAVIGATION_MODE_TABS){
+			maxItems = MAX_ACTION_BAR_ITEMS_PORTRAIT_TABS;
+		}
+		
 		if (getActivity().getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
 			maxItems = MAX_ACTION_BAR_ITEMS_LANDSCAPE;
 		}


### PR DESCRIPTION
Currently the items in the action bar take up too much space when using tab navigation. Landscape is ok, but in portrait the tabs become to small.

This commit reduces the available spaces to 1 while using tab navigation in portrait.
