### PR TITLE
Visual error when hiding ActionBar.

### DIFF
--- a/library/src/com/actionbarsherlock/internal/widget/ActionBarContainer.java
+++ b/library/src/com/actionbarsherlock/internal/widget/ActionBarContainer.java
@@ -16,10 +16,6 @@ public class ActionBarContainer extends FrameLayout {
     }
     public ActionBarContainer(Context context, AttributeSet attrs) {
         super(context, attrs);
-
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.SherlockTheme);
-        setBackgroundDrawable(a.getDrawable(R.styleable.SherlockTheme_abBackground));
-        a.recycle();
     }
 
     @Override


### PR DESCRIPTION
Hi,

I'm wondering why you are setting the ActionBar custom background (set using `abBackground` attribute) to both the `ActionBarContainer` and `ActionBarView`.

For me this causes a small visual error when hiding the action bar on pre-3.0 devices, as only the `ActionBarView` is hidden not the `ActionBarContainer`. I'm using a nine-patch as background image and the "non-content" part of the background image stays visible.

Removing the background image from the `ActionBarContainer` (see commit) has resolved this issue for me.

Regards
