### PR TITLE
Crash in FragmentManager when popping backstack and reusing fragments

### DIFF
--- a/library/src/android/support/v4/app/BackStackRecord.java
+++ b/library/src/android/support/v4/app/BackStackRecord.java
@@ -654,7 +654,7 @@ final class BackStackRecord extends FragmentTransaction implements
                     if (op.removed != null) {
                         for (int i=0; i<op.removed.size(); i++) {
                             Fragment old = op.removed.get(i);
-                            f.mImmediateActivity = mManager.mActivity;
+                            old.mImmediateActivity = mManager.mActivity;
                             mManager.addFragment(old, false);
                         }
                     }


### PR DESCRIPTION
Hi,

I think I have found a small bug in the `BackStackRecord` class. In the method `popFromBackStack(boolean)` you set the activity for the removed fragment instead of the newly added one (see patch).

This line caused the following exception:

```
java.lang.IllegalStateException: Fragment already added: MapFragment{40698d88}
    at android.support.v4.app.BackStackRecord.doAddOp(BackStackRecord.java:327)
    at android.support.v4.app.BackStackRecord.replace(BackStackRecord.java:371)
    at android.support.v4.app.BackStackRecord.replace(BackStackRecord.java:363)
    at com.example.MyMapActivity.onOptionsItemSelected(MyMapActivity.java:76)
    at android.support.v4.app.FragmentMapActivity.onMenuItemSelected(FragmentMapActivity.java:650)
    at android.support.v4.app.FragmentMapActivity$3.onMenuItemSelected(FragmentMapActivity.java:148)
    at com.actionbarsherlock.internal.view.menu.MenuItemImpl.invoke(MenuItemImpl.java:141)
    at com.actionbarsherlock.internal.view.menu.ActionMenuItemView.onClick(ActionMenuItemView.java:140)
    at android.view.View.performClick(View.java:2501)
    at android.view.View$PerformClick.run(View.java:9107)
    at android.os.Handler.handleCallback(Handler.java:587)
    at android.os.Handler.dispatchMessage(Handler.java:92)
    at android.os.Looper.loop(Looper.java:123)
    at android.app.ActivityThread.main(ActivityThread.java:3835)
    at java.lang.reflect.Method.invokeNative(Native Method)
    at java.lang.reflect.Method.invoke(Method.java:507)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:841)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:599)
    at dalvik.system.NativeStart.main(Native Method)
```

Here's what I try to do:
- Create activity with one fragment (call it `ListFragment`)
- Show fragment with `MapView` on it when user clicks button (`MapFragment`)
- User pops `MapFragment` off the backstack (`ListFragment` appears again)
- User tries to see map again (same instance of `MapFragment` will be added to `FragmentManager` again)
  -> **exception**

It works if the transaction which shows the `MapFragment` does not remove any other fragments (for example, when the `MapFragment` is the only fragment in the activity).

Regards
