### PR TITLE
Do not call onActivityResult on null fragment.

### DIFF
--- a/library/src/android/support/v4/app/FragmentActivity.java
+++ b/library/src/android/support/v4/app/FragmentActivity.java
@@ -364,8 +364,9 @@ public class FragmentActivity extends Activity implements SupportActivity {
             if (frag == null) {
                 Log.w(TAG, "Activity result no fragment exists for index: 0x"
                         + Integer.toHexString(requestCode));
+            } else {
+                frag.onActivityResult(requestCode&0xffff, resultCode, data);
             }
-            frag.onActivityResult(requestCode&0xffff, resultCode, data);
             return;
         }
 


### PR DESCRIPTION
Hi,

I think I've found a small bug in the library. As you can see the `FragmentActivity` checks in `onActivityResult` if the requesting fragment still exists and logs a warning if the reference is null. But it still runs into a NPE if the `Fragment` is null because the call to `Fragment.onActivityResult` is always done.

Is this the expected behaviour?

Regards
  Robert
