### PR TITLE
Fix DialogFragment dismissing on orientation change.

### DIFF
--- a/library/src/android/support/v4/app/DialogFragment.java
+++ b/library/src/android/support/v4/app/DialogFragment.java
@@ -361,7 +361,7 @@ public class DialogFragment extends Fragment
         if (!mCancelable) {
             outState.putBoolean(SAVED_CANCELABLE, mCancelable);
         }
-        if (!mShowsDialog) {
+        if (mShowsDialog) {
             outState.putBoolean(SAVED_SHOWS_DIALOG, mShowsDialog);
         }
         if (mBackStackId != -1) {


### PR DESCRIPTION
mShowsDialog indicates whether a DialogFragment is shown as a dialog. It's initiated as false, and changed to true if .show(...) is called on the DialogFragment.
However, on orientation change it is only saved if it's false, causing the dialog to not be shown, or crashing if getDialog() is called any time during creation.
