### PR TITLE
Menu resource onClick attribute is broken (refers to wrong object)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Version 3.3.1 *(In Development)*
 
  * XML-defined `onClick` attributes will now check for an `onClick` method that
    takes an `android.support.v4.view.MenuItem` instance.
+ * Fix: Menu inflater properly checks activity context for `onClick` method
+   declared in the XML.
+ * Fix: Dialog fragment properly saves its `showDialog` state when not being
+   used as a popup.
 
 
 Version 3.3.0 *(2011-10-11)*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ===============================================================================
 
+Version 3.3.1 *(In Development)*
+--------------------------------
+
+ * XML-defined `onClick` attributes will now check for an `onClick` method that
+   takes an `android.support.v4.view.MenuItem` instance.
+
+
 Version 3.3.0 *(2011-10-11)*
 ----------------------------
 

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>com.actionbarsherlock</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.3.0</version>
+		<version>3.3.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/library/src/android/support/v4/app/DialogFragment.java
+++ b/library/src/android/support/v4/app/DialogFragment.java
@@ -361,7 +361,7 @@ public class DialogFragment extends Fragment
         if (!mCancelable) {
             outState.putBoolean(SAVED_CANCELABLE, mCancelable);
         }
-        if (!mShowsDialog) {
+        if (mShowsDialog) {
             outState.putBoolean(SAVED_SHOWS_DIALOG, mShowsDialog);
         }
         if (mBackStackId != -1) {

--- a/library/src/android/support/v4/view/MenuInflater.java
+++ b/library/src/android/support/v4/view/MenuInflater.java
@@ -435,7 +435,7 @@ public final class MenuInflater extends android.view.MenuInflater {
         private Method mMethod;
 
         public InflatedOnMenuItemClickListener(String methodName) {
-            final Class<?> localClass = MenuInflater.this.getClass();
+            final Class<?> localClass = mContext.getClass();
             try {
                 mMethod = localClass.getMethod(methodName, PARAM_TYPES);
             } catch (Exception e) {
@@ -453,7 +453,7 @@ public final class MenuInflater extends android.view.MenuInflater {
             final Object[] params = new Object[] { item };
             try {
                 if (mMethod.getReturnType() == Boolean.TYPE) {
-                    return (Boolean)mMethod.invoke(MenuInflater.this, params);
+                    return (Boolean)mMethod.invoke(mContext, params);
                 }
                 return false;
             } catch (Exception e) {

--- a/library/src/android/support/v4/view/MenuInflater.java
+++ b/library/src/android/support/v4/view/MenuInflater.java
@@ -27,7 +27,6 @@ import android.content.res.XmlResourceParser;
 import android.util.AttributeSet;
 import android.util.Xml;
 import android.view.InflateException;
-import android.view.MenuItem;
 import android.view.View;
 import com.actionbarsherlock.internal.view.menu.MenuBuilder;
 import com.actionbarsherlock.internal.view.menu.MenuItemImpl;
@@ -44,7 +43,7 @@ import com.actionbarsherlock.internal.view.menu.SubMenuBuilder;
  */
 public final class MenuInflater extends android.view.MenuInflater {
     private static final Class<?>[] ACTION_VIEW_CONSTRUCTOR_SIGNATURE = new Class[] { Context.class };
-    private static final Class<?>[] PARAM_TYPES = new Class[] { android.view.MenuItem.class };
+    private static final Class<?>[] PARAM_TYPES = new Class[] { android.support.v4.view.MenuItem.class };
 
     /** Android XML namespace. */
     private static final String XML_NS = "http://schemas.android.com/apk/res/android";
@@ -431,7 +430,7 @@ public final class MenuInflater extends android.view.MenuInflater {
         }
     }
 
-    class InflatedOnMenuItemClickListener implements android.view.MenuItem.OnMenuItemClickListener {
+    class InflatedOnMenuItemClickListener extends android.support.v4.view.MenuItem.OnMenuItemClickListener {
         private Method mMethod;
 
         public InflatedOnMenuItemClickListener(String methodName) {

--- a/plugins/maps/pom.xml
+++ b/plugins/maps/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>com.actionbarsherlock</groupId>
 		<artifactId>parent-plugins</artifactId>
-		<version>3.3.0</version>
+		<version>3.3.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>com.actionbarsherlock</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.3.0</version>
+		<version>3.3.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.actionbarsherlock</groupId>
 	<artifactId>parent</artifactId>
 	<packaging>pom</packaging>
-	<version>3.3.0</version>
+	<version>3.3.1-SNAPSHOT</version>
 
 	<name>ActionBarSherlock (Parent)</name>
 	<description>Android library for implementing the action bar design pattern using the native ActionBar on 3.0+ and a custom implementation on pre-3.0 all through the same API.</description>

--- a/samples/demos/pom.xml
+++ b/samples/demos/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>com.actionbarsherlock</groupId>
 		<artifactId>parent-sample</artifactId>
-		<version>3.3.0</version>
+		<version>3.3.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>com.actionbarsherlock</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.3.0</version>
+		<version>3.3.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/shakespeare/pom.xml
+++ b/samples/shakespeare/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>com.actionbarsherlock</groupId>
 		<artifactId>parent-sample</artifactId>
-		<version>3.3.0</version>
+		<version>3.3.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/styled/pom.xml
+++ b/samples/styled/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>com.actionbarsherlock</groupId>
 		<artifactId>parent-sample</artifactId>
-		<version>3.3.0</version>
+		<version>3.3.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/test/app/pom.xml
+++ b/test/app/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>com.actionbarsherlock</groupId>
 		<artifactId>parent-test</artifactId>
-		<version>3.3.0</version>
+		<version>3.3.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>com.actionbarsherlock</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.3.0</version>
+		<version>3.3.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/test/runner/pom.xml
+++ b/test/runner/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>com.actionbarsherlock</groupId>
 		<artifactId>parent-test</artifactId>
-		<version>3.3.0</version>
+		<version>3.3.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/website/resources/download.html
+++ b/website/resources/download.html
@@ -15,7 +15,7 @@ $(function() {
 			return (o1.name > o2.name) ? -1 : 1;
 		});
 
-		var last = data[data.length - 1];
+		var last = data[0];
 		var lastSha = last.commit.sha;
 		var lastDate = $('#latest-date').html('<em>Date unavailable</em>');
 		$('.latest-version').html(last.name);


### PR DESCRIPTION
`MenuInflater` attempts to bind the `onClick` handlers to itself, rather than to the given Context. This patch fixes this.
