### PR TITLE
getSupportFragmentManager().findFragmentById(android.R.id.content) always returns null

### DIFF
--- a/library/src/android/support/v4/app/FragmentManager.java
+++ b/library/src/android/support/v4/app/FragmentManager.java
@@ -41,6 +41,7 @@ import android.view.animation.Animation.AnimationListener;
 import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import com.actionbarsherlock.R;
 
 import java.io.FileDescriptor;
 import java.io.PrintWriter;
@@ -1186,6 +1187,12 @@ final class FragmentManagerImpl extends FragmentManager {
     }
 
     public Fragment findFragmentById(int id) {
+        if (!HONEYCOMB && (id == android.R.id.content)) {
+            // android.R.id.content would point to the entire content area,
+            // including the custom action bar
+            return findFragmentById(R.id.abs__content);
+        }
+
         if (mActive != null) {
             // First look through added fragments.
             for (int i=mAdded.size()-1; i>=0; i--) {


### PR DESCRIPTION
`android.R.id.content` is implicitly remapped to `R.id.abs__content` in [BackStackRecord](/JakeWharton/ActionBarSherlock/blob/8aed59f4be0850d2a6ace518d89a54693db5bbd9/library/src/android/support/v4/app/BackStackRecord.java#L345). The same should be done in `FragmentManager#findFragmentById`, and possibly any other place that performs id-based lookup that I may have missed.
