### PR TITLE
Fix NPE when calling ActionBarImpl.getNavigationItemCount() when tab navigation is enabled and no tab is actually selected. Return -1 in this case, which is what the Honeycomb implementation does.

### DIFF
--- a/library/src/com/actionbarsherlock/internal/app/ActionBarImpl.java
+++ b/library/src/com/actionbarsherlock/internal/app/ActionBarImpl.java
@@ -256,6 +256,8 @@ public final class ActionBarImpl extends ActionBar {
                 return mActionView.getDropdownSelectedPosition();
 
             case ActionBar.NAVIGATION_MODE_TABS:
+                if (mActionView.getSelectedTab() == null)
+                    return -1;
                 return mActionView.getSelectedTab().getPosition();
         }
     }


### PR DESCRIPTION
Returning -1 is undocumented behavior, but empirical observation reveals this to be a part of Google's implementation.
