### PR TITLE
Fix ArrayIndexOutOfBoundsException when removing a menu group

### DIFF
--- a/library/src/com/actionbarsherlock/internal/view/menu/MenuBuilder.java
+++ b/library/src/com/actionbarsherlock/internal/view/menu/MenuBuilder.java
@@ -359,10 +359,12 @@ public class MenuBuilder implements Menu {
 
     @Override
     public void removeGroup(int groupId) {
-        final int size = this.mItems.size();
+        int size = this.mItems.size();
         for (int i = 0; i < size; i++) {
             if (this.mItems.get(i).getGroupId() == groupId) {
                 this.mItems.remove(i);
+                i--;
+                size--;
             }
         }
     }


### PR DESCRIPTION
Fix ArrayIndexOutOfBoundsException when removing a menu group from the overflow menu.

After removing an item, decrement the loop iterator so we don't walk off the end of the array.
