### PR TITLE
Fix two NPEs in ActionBarWrapper

### DIFF
--- a/library/src/com/actionbarsherlock/internal/app/ActionBarWrapper.java
+++ b/library/src/com/actionbarsherlock/internal/app/ActionBarWrapper.java
@@ -394,7 +394,9 @@ public final class ActionBarWrapper {
 
         @Override
         public Tab getSelectedTab() {
-            return (ActionBar.Tab)getActionBar().getSelectedTab().getTag();
+        	if (getActionBar().getSelectedTab() != null) 
+        		return (ActionBar.Tab)getActionBar().getSelectedTab().getTag();
+        	return null;
         }
 
         @Override
@@ -404,7 +406,9 @@ public final class ActionBarWrapper {
 
         @Override
         public ActionBar.Tab getTabAt(int index) {
-            return (Tab)getActionBar().getTabAt(index).getTag();
+        	if (getActionBar().getTabAt(index) != null)
+        		return (Tab)getActionBar().getTabAt(index).getTag();
+        	return null;
         }
 
         @Override


### PR DESCRIPTION
Fix two NPEs in ActionBarWrapper that occured when calling getSelectedTab or getTabAt when no tab was selected or no tab was at the specified index. Added null checks. Honeycomb only.

This makes the behavior in these cases be the same as Android 3.2's implementation.
