### PR TITLE
NPE fix.

### DIFF
--- a/library/src/android/support/v4/app/FragmentManager.java
+++ b/library/src/android/support/v4/app/FragmentManager.java
@@ -1572,6 +1572,9 @@ final class FragmentManagerImpl extends FragmentManager {
                     FragmentManagerImpl.VIEW_STATE_TAG, f.mSavedViewState);
         }
         if (!f.mUserVisibleHint) {
+        	if (result == null) {
+        		result = new Bundle();
+        	}
             // Only add this if it's not the default value
             result.putBoolean(FragmentManagerImpl.USER_VISIBLE_HINT_TAG, f.mUserVisibleHint);
         }


### PR DESCRIPTION
I've taken com.actionbarsherlock.sample.demos.app.ActionBarTabsPager as an example.
An app with 2 tabs, each contains it's own Fragment. A NPE occurs when launching an Activity from one of the Fragments.
