### PR TITLE
NullPointerException in FragmentManager.saveFragmentBasicState(...)

### DIFF
--- a/library/src/android/support/v4/app/FragmentManager.java
+++ b/library/src/android/support/v4/app/FragmentManager.java
@@ -1572,6 +1572,9 @@ final class FragmentManagerImpl extends FragmentManager {
                     FragmentManagerImpl.VIEW_STATE_TAG, f.mSavedViewState);
         }
         if (!f.mUserVisibleHint) {
+            if (result == null) {
+                result = new Bundle();
+            }
             // Only add this if it's not the default value
             result.putBoolean(FragmentManagerImpl.USER_VISIBLE_HINT_TAG, f.mUserVisibleHint);
         }


### PR DESCRIPTION
FragmentManager: prevented NullPointerException when saving some types of Fragments where mSavedViewState is null and mUserVisibleHint is false.

Instances of this class were causing the NPE:

public abstract class LayoutFragment extends Fragment {

```
public static LayoutFragment newInstance(final int layoutId) {
    return new LayoutFragment() {
        @Override
        public int getLayoutResourceId() {
            return layoutId;
        }
    };
}

public abstract int getLayoutResourceId();

@Override
public View onCreateView(LayoutInflater inflater, ViewGroup container,
        Bundle savedInstanceState) {
    return inflater.inflate(getLayoutResourceId(), container, false);
}
```

}
