### PR TITLE
Minor changes to compatibility actionbar

### DIFF
--- a/library/res/layout/abs__action_bar.xml
+++ b/library/res/layout/abs__action_bar.xml
@@ -76,16 +76,25 @@
 				android:visibility="gone" />
 		</RelativeLayout>
 	</RelativeLayout>
-	<LinearLayout
-		android:id="@+id/abs__nav_tabs"
-		android:layout_width="fill_parent"
-		android:layout_height="44dp"
-		android:focusable="true"
-		android:visibility="visible"
-		android:orientation="horizontal"
-		android:gravity="center_vertical"
-		android:tag="@string/abs__tab_under_ab_tag"
-		android:background="?abBackgroundStacked"
-		style="?actionBarTabBarStyle" />
+	<HorizontalScrollView
+        android:id="@+id/abs__nav_tabs_layout"
+        android:layout_width="wrap_content"
+        android:layout_height="fill_parent"
+        android:layout_alignParentLeft="true"
+        android:layout_alignWithParentIfMissing="true"
+        android:layout_toLeftOf="@id/abs__iprogress"
+        android:scrollbars="none" >
 
+        <LinearLayout
+            android:id="@+id/abs__nav_tabs"
+            style="?actionBarTabBarStyle"
+            android:layout_width="fill_parent"
+            android:layout_height="44dp"
+            android:background="?abBackgroundStacked"
+            android:focusable="true"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:tag="@string/abs__tab_under_ab_tag"
+            android:visibility="visible" />
+    </HorizontalScrollView>
 </LinearLayout>

--- a/library/src/com/actionbarsherlock/internal/widget/ActionBarView.java
+++ b/library/src/com/actionbarsherlock/internal/widget/ActionBarView.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.TypedArray;
+import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.support.v4.app.ActionBar;
 import android.support.v4.view.Menu;
@@ -22,6 +23,7 @@ import android.widget.RelativeLayout;
 import android.widget.Spinner;
 import android.widget.SpinnerAdapter;
 import android.widget.TextView;
+
 import com.actionbarsherlock.R;
 import com.actionbarsherlock.internal.view.menu.ActionMenuItem;
 import com.actionbarsherlock.internal.view.menu.ActionMenuPresenter;
@@ -535,6 +537,13 @@ public final class ActionBarView extends RelativeLayout {
             TabImpl existingTab = (TabImpl)mTabsView.getChildAt(i).getTag();
             if (existingTab.equals(tab)) {
                 existingTab.select();
+                
+				if (mTabViewContainer != null && existingTab.mView != null) {
+					Rect rect = new Rect();
+					existingTab.mView.getDrawingRect(rect);
+					mTabViewContainer.requestChildRectangleOnScreen(
+							existingTab.mView, rect, true);
+				}
                 break;
             }
         }


### PR DESCRIPTION
- changed portrait version of compatibility action bar so that it sits
  in a horizontal scroll view - this looked really weird when there were
  too many tabs especially that all the auto scrolling text was moving
  that the same time - requires more that 4 tabs to test
- changed action bar view so that when a tab is selected (without user
  input) it scrolls into view if it was not visible - this matches
  behaviour in ICS (not sure about HC)
