### PR TITLE
Fix for totally unqualified activity class names

### DIFF
--- a/library/src/com/actionbarsherlock/ActionBarSherlock.java
+++ b/library/src/com/actionbarsherlock/ActionBarSherlock.java
@@ -957,7 +957,11 @@ public final class ActionBarSherlock {
                             } else if ("name".equals(attrName)) {
                                 activityPackage = xml.getAttributeValue(i);
                                 //Handle FQCN or relative
-                                if (!activityPackage.startsWith(packageName) && activityPackage.startsWith(".")) {
+                                if (!activityPackage.startsWith(packageName)) {
+                                    //Handle unqualified package name
+                                    if(!activityPackage.startsWith(".")) {
+                                        activityPackage = "." + activityPackage;
+                                    }
                                     activityPackage = packageName + activityPackage;
                                 }
                                 if (!thisPackage.equals(activityPackage)) {

--- a/library/src/com/actionbarsherlock/ActionBarSherlock.java
+++ b/library/src/com/actionbarsherlock/ActionBarSherlock.java
@@ -957,9 +957,9 @@ public final class ActionBarSherlock {
                             } else if ("name".equals(attrName)) {
                                 activityPackage = xml.getAttributeValue(i);
                                 //Handle FQCN or relative
-                                if (!activityPackage.startsWith(packageName)) {
+                                if (activityPackage.indexOf('.', 1) == -1) {
                                     //Handle unqualified package name
-                                    if(!activityPackage.startsWith(".")) {
+                                    if (!activityPackage.startsWith(".")) {
                                         activityPackage = "." + activityPackage;
                                     }
                                     activityPackage = packageName + activityPackage;

--- a/library/src/com/actionbarsherlock/internal/widget/ActionBarView.java
+++ b/library/src/com/actionbarsherlock/internal/widget/ActionBarView.java
@@ -316,7 +316,11 @@ public class ActionBarView extends AbsActionBarView {
                             } else if ("name".equals(attrName)) {
                                 activityPackage = xml.getAttributeValue(i);
                                 //Handle FQCN or relative
-                                if (!activityPackage.startsWith(packageName) && activityPackage.startsWith(".")) {
+                                if (!activityPackage.startsWith(packageName)) {
+                                    //Handle unqualified package name
+                                    if(!activityPackage.startsWith(".")) {
+                                        activityPackage = "." + activityPackage;
+                                    }
                                     activityPackage = packageName + activityPackage;
                                 }
                                 if (!thisPackage.equals(activityPackage)) {

--- a/library/src/com/actionbarsherlock/internal/widget/ActionBarView.java
+++ b/library/src/com/actionbarsherlock/internal/widget/ActionBarView.java
@@ -316,9 +316,9 @@ public class ActionBarView extends AbsActionBarView {
                             } else if ("name".equals(attrName)) {
                                 activityPackage = xml.getAttributeValue(i);
                                 //Handle FQCN or relative
-                                if (!activityPackage.startsWith(packageName)) {
+                                if (activityPackage.indexOf('.', 1) == -1) {
                                     //Handle unqualified package name
-                                    if(!activityPackage.startsWith(".")) {
+                                    if (!activityPackage.startsWith(".")) {
                                         activityPackage = "." + activityPackage;
                                     }
                                     activityPackage = packageName + activityPackage;


### PR DESCRIPTION
Activity class names in the manifest are _supposed_ to be either fully qualified or relative to the current package, but the OS allows totally unqualified names.
This fix is to allow the reading of totally unqualified Activity class names to comply with the OS behaviour.
Closes #201.
