### PR TITLE
Improve eclipse integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ gen
 .project
 .classpath
 .settings
+.checkstyle
 
 #IntelliJ IDEA
 .idea

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -100,5 +100,40 @@
 				</executions>
 			</plugin>
 		</plugins>
+		<pluginManagement>
+			<plugins>
+				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+				<plugin>
+					<groupId>org.eclipse.m2e</groupId>
+					<artifactId>lifecycle-mapping</artifactId>
+					<version>1.0.0</version>
+					<configuration>
+						<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>
+											com.google.code.maven-replacer-plugin
+										</groupId>
+										<artifactId>
+											maven-replacer-plugin
+										</artifactId>
+										<versionRange>
+											[1.4.1,)
+										</versionRange>
+										<goals>
+											<goal>replace</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore></ignore>
+									</action>
+								</pluginExecution>
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 </project>


### PR DESCRIPTION
Two changes:
1. Add .checkstyle generated by eclipse to .gitignore
2. Ignore executing of com.google.code.maven-replacer-plugin using eclipse since eclipse does not know how to handle the plugin.
