### PR TITLE
Fix NullPointerException with SherlockMapActivity

### DIFF
--- a/library/src/com/actionbarsherlock/ActionBarSherlock.java
+++ b/library/src/com/actionbarsherlock/ActionBarSherlock.java
@@ -181,7 +181,6 @@ public abstract class ActionBarSherlock {
         HashMap<Implementation, Class<? extends ActionBarSherlock>> impls =
                 new HashMap<Implementation, Class<? extends ActionBarSherlock>>(IMPLEMENTATIONS);
         boolean hasQualfier;
-        final boolean isTvDpi = activity.getResources().getDisplayMetrics().densityDpi == DisplayMetrics.DENSITY_TV;
 
         /* DPI FILTERING */
         hasQualfier = false;
@@ -193,7 +192,7 @@ public abstract class ActionBarSherlock {
             }
         }
         if (hasQualfier) {
-            //final boolean isTvDpi = activity.getResources().getDisplayMetrics().densityDpi == DisplayMetrics.DENSITY_TV;
+            final boolean isTvDpi = activity.getResources().getDisplayMetrics().densityDpi == DisplayMetrics.DENSITY_TV;
             for (Iterator<Implementation> keys = impls.keySet().iterator(); keys.hasNext(); ) {
                 int keyDpi = keys.next().dpi();
                 if ((isTvDpi && keyDpi != DisplayMetrics.DENSITY_TV)


### PR DESCRIPTION
Using 4.0 HEAD library with RC maps library causes a NullPointerException during the construction of a SherlockMapActivity.  Stack Trace:

FATAL EXCEPTION: main
java.lang.RuntimeException: Unable to instantiate activity ComponentInfo{me.kevinwells.derp/me.kevinwells.derp.DerpActivity}: java.lang.NullPointerException
      at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:1569)
      at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:1663)
      at android.app.ActivityThread.access$1500(ActivityThread.java:117)
      at android.app.ActivityThread$H.handleMessage(ActivityThread.java:931)
      at android.os.Handler.dispatchMessage(Handler.java:99)
      at android.os.Looper.loop(Looper.java:130)
      at android.app.ActivityThread.main(ActivityThread.java:3683)
      at java.lang.reflect.Method.invokeNative(Native Method)
      at java.lang.reflect.Method.invoke(Method.java:507)
      at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:839)
      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:597)
      at dalvik.system.NativeStart.main(Native Method)
Caused by: java.lang.NullPointerException
      at android.content.ContextWrapper.getResources(ContextWrapper.java:80)
      at com.actionbarsherlock.ActionBarSherlock.wrap(ActionBarSherlock.java:190)
      at com.actionbarsherlock.app.SherlockMapActivity.<init>(SherlockMapActivity.java:30)
      at com.actionbarsherlock.app.SherlockMapActivity.<init>(SherlockMapActivity.java:26)
      at me.kevinwells.derp.DerpActivity.<init>(DerpActivity.java:7)
      at java.lang.Class.newInstanceImpl(Native Method)
      at java.lang.Class.newInstance(Class.java:1409)
      at android.app.Instrumentation.newActivity(Instrumentation.java:1021)
      at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:1561)
      ... 11 more

This change moves the getResources() call to only the cases that need it.  Tested on Nexus S running 2.3.6.
