### PR TITLE
Support for ADT 17 Lint checks

### DIFF
--- a/library/src/com/actionbarsherlock/TargetApi.java
+++ b/library/src/com/actionbarsherlock/TargetApi.java
@@ -1,0 +1,15 @@
+
+package com.actionbarsherlock;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.CONSTRUCTOR})
+@Retention(RetentionPolicy.CLASS)
+public @interface TargetApi {
+
+    public static final int CURRENT = 14;
+    
+    public abstract int value();
+}

--- a/library/src/com/actionbarsherlock/app/SherlockActivity.java
+++ b/library/src/com/actionbarsherlock/app/SherlockActivity.java
@@ -5,19 +5,22 @@ import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import android.view.View;
-import android.view.Window;
 import android.view.ViewGroup.LayoutParams;
+import android.view.Window;
+
 import com.actionbarsherlock.ActionBarSherlock;
 import com.actionbarsherlock.ActionBarSherlock.OnActionModeFinishedListener;
 import com.actionbarsherlock.ActionBarSherlock.OnActionModeStartedListener;
 import com.actionbarsherlock.ActionBarSherlock.OnCreatePanelMenuListener;
 import com.actionbarsherlock.ActionBarSherlock.OnMenuItemSelectedListener;
 import com.actionbarsherlock.ActionBarSherlock.OnPreparePanelListener;
+import com.actionbarsherlock.TargetApi;
 import com.actionbarsherlock.view.ActionMode;
 import com.actionbarsherlock.view.Menu;
 import com.actionbarsherlock.view.MenuInflater;
 import com.actionbarsherlock.view.MenuItem;
 
+@TargetApi(TargetApi.CURRENT)
 public abstract class SherlockActivity extends Activity implements OnCreatePanelMenuListener, OnPreparePanelListener, OnMenuItemSelectedListener, OnActionModeStartedListener, OnActionModeFinishedListener {
     private ActionBarSherlock mSherlock;
 

--- a/library/src/com/actionbarsherlock/app/SherlockExpandableListActivity.java
+++ b/library/src/com/actionbarsherlock/app/SherlockExpandableListActivity.java
@@ -7,17 +7,20 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.view.Window;
+
 import com.actionbarsherlock.ActionBarSherlock;
 import com.actionbarsherlock.ActionBarSherlock.OnActionModeFinishedListener;
 import com.actionbarsherlock.ActionBarSherlock.OnActionModeStartedListener;
 import com.actionbarsherlock.ActionBarSherlock.OnCreatePanelMenuListener;
 import com.actionbarsherlock.ActionBarSherlock.OnMenuItemSelectedListener;
 import com.actionbarsherlock.ActionBarSherlock.OnPreparePanelListener;
+import com.actionbarsherlock.TargetApi;
 import com.actionbarsherlock.view.ActionMode;
 import com.actionbarsherlock.view.Menu;
 import com.actionbarsherlock.view.MenuInflater;
 import com.actionbarsherlock.view.MenuItem;
 
+@TargetApi(TargetApi.CURRENT)
 public abstract class SherlockExpandableListActivity extends ExpandableListActivity implements OnCreatePanelMenuListener, OnPreparePanelListener, OnMenuItemSelectedListener, OnActionModeStartedListener, OnActionModeFinishedListener {
     private ActionBarSherlock mSherlock;
 

--- a/library/src/com/actionbarsherlock/app/SherlockListActivity.java
+++ b/library/src/com/actionbarsherlock/app/SherlockListActivity.java
@@ -5,19 +5,22 @@ import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import android.view.View;
-import android.view.Window;
 import android.view.ViewGroup.LayoutParams;
+import android.view.Window;
+
 import com.actionbarsherlock.ActionBarSherlock;
 import com.actionbarsherlock.ActionBarSherlock.OnActionModeFinishedListener;
 import com.actionbarsherlock.ActionBarSherlock.OnActionModeStartedListener;
 import com.actionbarsherlock.ActionBarSherlock.OnCreatePanelMenuListener;
 import com.actionbarsherlock.ActionBarSherlock.OnMenuItemSelectedListener;
 import com.actionbarsherlock.ActionBarSherlock.OnPreparePanelListener;
+import com.actionbarsherlock.TargetApi;
 import com.actionbarsherlock.view.ActionMode;
 import com.actionbarsherlock.view.Menu;
 import com.actionbarsherlock.view.MenuInflater;
 import com.actionbarsherlock.view.MenuItem;
 
+@TargetApi(TargetApi.CURRENT)
 public abstract class SherlockListActivity extends ListActivity implements OnCreatePanelMenuListener, OnPreparePanelListener, OnMenuItemSelectedListener, OnActionModeStartedListener, OnActionModeFinishedListener {
     private ActionBarSherlock mSherlock;
 

--- a/library/src/com/actionbarsherlock/app/SherlockPreferenceActivity.java
+++ b/library/src/com/actionbarsherlock/app/SherlockPreferenceActivity.java
@@ -7,17 +7,20 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.view.Window;
+
 import com.actionbarsherlock.ActionBarSherlock;
 import com.actionbarsherlock.ActionBarSherlock.OnActionModeFinishedListener;
 import com.actionbarsherlock.ActionBarSherlock.OnActionModeStartedListener;
 import com.actionbarsherlock.ActionBarSherlock.OnCreatePanelMenuListener;
 import com.actionbarsherlock.ActionBarSherlock.OnMenuItemSelectedListener;
 import com.actionbarsherlock.ActionBarSherlock.OnPreparePanelListener;
+import com.actionbarsherlock.TargetApi;
 import com.actionbarsherlock.view.ActionMode;
 import com.actionbarsherlock.view.Menu;
 import com.actionbarsherlock.view.MenuInflater;
 import com.actionbarsherlock.view.MenuItem;
 
+@TargetApi(TargetApi.CURRENT)
 public abstract class SherlockPreferenceActivity extends PreferenceActivity implements OnCreatePanelMenuListener, OnPreparePanelListener, OnMenuItemSelectedListener, OnActionModeStartedListener, OnActionModeFinishedListener {
     private ActionBarSherlock mSherlock;
 

--- a/library/src/com/actionbarsherlock/internal/ActionBarSherlockNative.java
+++ b/library/src/com/actionbarsherlock/internal/ActionBarSherlockNative.java
@@ -1,20 +1,23 @@
 package com.actionbarsherlock.internal;
 
-import com.actionbarsherlock.ActionBarSherlock;
-import com.actionbarsherlock.app.ActionBar;
-import com.actionbarsherlock.internal.app.ActionBarWrapper;
-import com.actionbarsherlock.internal.view.menu.MenuWrapper;
-import com.actionbarsherlock.view.ActionMode;
-import com.actionbarsherlock.view.MenuInflater;
 import android.app.Activity;
 import android.content.Context;
 import android.util.Log;
 import android.util.TypedValue;
 import android.view.ContextThemeWrapper;
 import android.view.View;
-import android.view.Window;
 import android.view.ViewGroup.LayoutParams;
+import android.view.Window;
 
+import com.actionbarsherlock.ActionBarSherlock;
+import com.actionbarsherlock.TargetApi;
+import com.actionbarsherlock.app.ActionBar;
+import com.actionbarsherlock.internal.app.ActionBarWrapper;
+import com.actionbarsherlock.internal.view.menu.MenuWrapper;
+import com.actionbarsherlock.view.ActionMode;
+import com.actionbarsherlock.view.MenuInflater;
+
+@TargetApi(TargetApi.CURRENT)
 @ActionBarSherlock.Implementation(api = 14)
 public class ActionBarSherlockNative extends ActionBarSherlock {
     private ActionBarWrapper mActionBar;
@@ -213,6 +216,7 @@ public class ActionBarSherlockNative extends ActionBarSherlock {
         return mActionMode;
     }
 
+    @TargetApi(TargetApi.CURRENT)
     private class ActionModeCallbackWrapper implements android.view.ActionMode.Callback {
         private final ActionMode.Callback mCallback;
 
@@ -244,6 +248,7 @@ public class ActionBarSherlockNative extends ActionBarSherlock {
         }
     }
 
+    @TargetApi(TargetApi.CURRENT)
     private class ActionModeWrapper extends ActionMode {
         private final android.view.ActionMode mActionMode;
         private MenuWrapper mMenu = null;

--- a/library/src/com/actionbarsherlock/internal/app/ActionBarImpl.java
+++ b/library/src/com/actionbarsherlock/internal/app/ActionBarImpl.java
@@ -16,8 +16,8 @@
 
 package com.actionbarsherlock.internal.app;
 
-import java.lang.ref.WeakReference;
-import java.util.ArrayList;
+import static com.actionbarsherlock.internal.ResourcesCompat.getResources_getBoolean;
+
 import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
@@ -33,13 +33,15 @@ import android.view.View;
 import android.view.Window;
 import android.view.accessibility.AccessibilityEvent;
 import android.widget.SpinnerAdapter;
+
 import com.actionbarsherlock.R;
+import com.actionbarsherlock.TargetApi;
 import com.actionbarsherlock.app.ActionBar;
 import com.actionbarsherlock.internal.nineoldandroids.animation.Animator;
+import com.actionbarsherlock.internal.nineoldandroids.animation.Animator.AnimatorListener;
 import com.actionbarsherlock.internal.nineoldandroids.animation.AnimatorListenerAdapter;
 import com.actionbarsherlock.internal.nineoldandroids.animation.AnimatorSet;
 import com.actionbarsherlock.internal.nineoldandroids.animation.ObjectAnimator;
-import com.actionbarsherlock.internal.nineoldandroids.animation.Animator.AnimatorListener;
 import com.actionbarsherlock.internal.nineoldandroids.widget.NineFrameLayout;
 import com.actionbarsherlock.internal.view.menu.MenuBuilder;
 import com.actionbarsherlock.internal.view.menu.MenuPopupHelper;
@@ -52,7 +54,9 @@ import com.actionbarsherlock.view.ActionMode;
 import com.actionbarsherlock.view.Menu;
 import com.actionbarsherlock.view.MenuInflater;
 import com.actionbarsherlock.view.MenuItem;
-import static com.actionbarsherlock.internal.ResourcesCompat.getResources_getBoolean;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 
 /**
  * ActionBarImpl is the ActionBar implementation used
@@ -61,6 +65,7 @@ import static com.actionbarsherlock.internal.ResourcesCompat.getResources_getBoo
  * the top of the screen and a horizontal LinearLayout at the bottom
  * which is normally hidden.
  */
+@TargetApi(TargetApi.CURRENT)
 public class ActionBarImpl extends ActionBar {
     //UNUSED private static final String TAG = "ActionBarImpl";
 
@@ -107,6 +112,7 @@ public class ActionBarImpl extends ActionBar {
 
     final AnimatorListener mHideListener = new AnimatorListenerAdapter() {
         @Override
+        @TargetApi(TargetApi.CURRENT)
         public void onAnimationEnd(Animator animation) {
             if (mContentView != null) {
                 mContentView.setTranslationY(0);

--- a/library/src/com/actionbarsherlock/internal/app/ActionBarWrapper.java
+++ b/library/src/com/actionbarsherlock/internal/app/ActionBarWrapper.java
@@ -1,8 +1,5 @@
 package com.actionbarsherlock.internal.app;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import android.app.Activity;
 import android.app.FragmentTransaction;
 import android.content.Context;
@@ -10,8 +7,13 @@ import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.widget.SpinnerAdapter;
 
+import com.actionbarsherlock.TargetApi;
 import com.actionbarsherlock.app.ActionBar;
 
+import java.util.HashSet;
+import java.util.Set;
+
+@TargetApi(TargetApi.CURRENT)
 public class ActionBarWrapper extends ActionBar implements android.app.ActionBar.OnNavigationListener, android.app.ActionBar.OnMenuVisibilityListener {
     private final android.app.ActionBar mActionBar;
     private ActionBar.OnNavigationListener mNavigationListener;
@@ -205,6 +207,7 @@ public class ActionBarWrapper extends ActionBar implements android.app.ActionBar
         return mActionBar.getDisplayOptions();
     }
 
+    @TargetApi(TargetApi.CURRENT)
     public static class TabWrapper extends ActionBar.Tab implements android.app.ActionBar.TabListener {
         final android.app.ActionBar.Tab mNativeTab;
         private Object mTag;

--- a/library/src/com/actionbarsherlock/internal/nineoldandroids/view/NineViewGroup.java
+++ b/library/src/com/actionbarsherlock/internal/nineoldandroids/view/NineViewGroup.java
@@ -4,8 +4,10 @@ import android.content.Context;
 import android.util.AttributeSet;
 import android.view.ViewGroup;
 
+import com.actionbarsherlock.TargetApi;
 import com.actionbarsherlock.internal.nineoldandroids.view.animation.AnimatorProxy;
 
+@TargetApi(TargetApi.CURRENT)
 public abstract class NineViewGroup extends ViewGroup {
     private final AnimatorProxy mProxy;
 

--- a/library/src/com/actionbarsherlock/internal/nineoldandroids/widget/NineFrameLayout.java
+++ b/library/src/com/actionbarsherlock/internal/nineoldandroids/widget/NineFrameLayout.java
@@ -1,11 +1,14 @@
+
 package com.actionbarsherlock.internal.nineoldandroids.widget;
 
 import android.content.Context;
 import android.util.AttributeSet;
 import android.widget.FrameLayout;
 
+import com.actionbarsherlock.TargetApi;
 import com.actionbarsherlock.internal.nineoldandroids.view.animation.AnimatorProxy;
 
+@TargetApi(TargetApi.CURRENT)
 public class NineFrameLayout extends FrameLayout {
     private final AnimatorProxy mProxy;
 
@@ -13,10 +16,12 @@ public class NineFrameLayout extends FrameLayout {
         super(context);
         mProxy = AnimatorProxy.NEEDS_PROXY ? AnimatorProxy.wrap(this) : null;
     }
+
     public NineFrameLayout(Context context, AttributeSet attrs) {
         super(context, attrs);
         mProxy = AnimatorProxy.NEEDS_PROXY ? AnimatorProxy.wrap(this) : null;
     }
+
     public NineFrameLayout(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
         mProxy = AnimatorProxy.NEEDS_PROXY ? AnimatorProxy.wrap(this) : null;
@@ -41,6 +46,7 @@ public class NineFrameLayout extends FrameLayout {
             return super.getAlpha();
         }
     }
+
     public void setAlpha(float alpha) {
         if (AnimatorProxy.NEEDS_PROXY) {
             mProxy.setAlpha(alpha);
@@ -48,6 +54,7 @@ public class NineFrameLayout extends FrameLayout {
             super.setAlpha(alpha);
         }
     }
+
     public float getTranslationY() {
         if (AnimatorProxy.NEEDS_PROXY) {
             return mProxy.getTranslationY();
@@ -55,6 +62,7 @@ public class NineFrameLayout extends FrameLayout {
             return super.getTranslationY();
         }
     }
+
     public void setTranslationY(float translationY) {
         if (AnimatorProxy.NEEDS_PROXY) {
             mProxy.setTranslationY(translationY);

--- a/library/src/com/actionbarsherlock/internal/nineoldandroids/widget/NineLinearLayout.java
+++ b/library/src/com/actionbarsherlock/internal/nineoldandroids/widget/NineLinearLayout.java
@@ -1,11 +1,14 @@
+
 package com.actionbarsherlock.internal.nineoldandroids.widget;
 
 import android.content.Context;
 import android.util.AttributeSet;
 import android.widget.LinearLayout;
 
+import com.actionbarsherlock.TargetApi;
 import com.actionbarsherlock.internal.nineoldandroids.view.animation.AnimatorProxy;
 
+@TargetApi(TargetApi.CURRENT)
 public class NineLinearLayout extends LinearLayout {
     private final AnimatorProxy mProxy;
 
@@ -13,10 +16,12 @@ public class NineLinearLayout extends LinearLayout {
         super(context);
         mProxy = AnimatorProxy.NEEDS_PROXY ? AnimatorProxy.wrap(this) : null;
     }
+
     public NineLinearLayout(Context context, AttributeSet attrs) {
         super(context, attrs);
         mProxy = AnimatorProxy.NEEDS_PROXY ? AnimatorProxy.wrap(this) : null;
     }
+
     public NineLinearLayout(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
         mProxy = AnimatorProxy.NEEDS_PROXY ? AnimatorProxy.wrap(this) : null;
@@ -41,6 +46,7 @@ public class NineLinearLayout extends LinearLayout {
             return super.getAlpha();
         }
     }
+
     public void setAlpha(float alpha) {
         if (AnimatorProxy.NEEDS_PROXY) {
             mProxy.setAlpha(alpha);
@@ -48,6 +54,7 @@ public class NineLinearLayout extends LinearLayout {
             super.setAlpha(alpha);
         }
     }
+
     public float getTranslationX() {
         if (AnimatorProxy.NEEDS_PROXY) {
             return mProxy.getTranslationX();
@@ -55,6 +62,7 @@ public class NineLinearLayout extends LinearLayout {
             return super.getTranslationX();
         }
     }
+
     public void setTranslationX(float translationX) {
         if (AnimatorProxy.NEEDS_PROXY) {
             mProxy.setTranslationX(translationX);

--- a/library/src/com/actionbarsherlock/internal/view/ActionProviderWrapper.java
+++ b/library/src/com/actionbarsherlock/internal/view/ActionProviderWrapper.java
@@ -1,18 +1,20 @@
+
 package com.actionbarsherlock.internal.view;
 
-import com.actionbarsherlock.internal.view.menu.SubMenuWrapper;
-import com.actionbarsherlock.view.ActionProvider;
 import android.view.View;
 
+import com.actionbarsherlock.TargetApi;
+import com.actionbarsherlock.internal.view.menu.SubMenuWrapper;
+import com.actionbarsherlock.view.ActionProvider;
+
+@TargetApi(TargetApi.CURRENT)
 public class ActionProviderWrapper extends android.view.ActionProvider {
     private final ActionProvider mProvider;
 
-
     public ActionProviderWrapper(ActionProvider provider) {
-        super(null/*TODO*/); //XXX this *should* be unused
+        super(null/* TODO */); // XXX this *should* be unused
         mProvider = provider;
     }
-
 
     public ActionProvider unwrap() {
         return mProvider;

--- a/library/src/com/actionbarsherlock/internal/view/menu/ActionMenuItemView.java
+++ b/library/src/com/actionbarsherlock/internal/view/menu/ActionMenuItemView.java
@@ -16,8 +16,8 @@
 
 package com.actionbarsherlock.internal.view.menu;
 
-import java.util.HashSet;
-import java.util.Set;
+import static com.actionbarsherlock.internal.ResourcesCompat.getResources_getBoolean;
+
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Rect;
@@ -34,15 +34,18 @@ import android.widget.LinearLayout;
 import android.widget.Toast;
 
 import com.actionbarsherlock.R;
+import com.actionbarsherlock.TargetApi;
 import com.actionbarsherlock.internal.view.View_HasStateListenerSupport;
 import com.actionbarsherlock.internal.view.View_OnAttachStateChangeListener;
 import com.actionbarsherlock.internal.widget.CapitalizingButton;
 
-import static com.actionbarsherlock.internal.ResourcesCompat.getResources_getBoolean;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @hide
  */
+@TargetApi(TargetApi.CURRENT)
 public class ActionMenuItemView extends LinearLayout
         implements MenuView.ItemView, View.OnClickListener, View.OnLongClickListener,
         ActionMenuView.ActionMenuChildView, View_HasStateListenerSupport {

--- a/library/src/com/actionbarsherlock/internal/view/menu/ActionMenuPresenter.java
+++ b/library/src/com/actionbarsherlock/internal/view/menu/ActionMenuPresenter.java
@@ -17,9 +17,7 @@
 package com.actionbarsherlock.internal.view.menu;
 
 import static com.actionbarsherlock.internal.ResourcesCompat.getResources_getInteger;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Set;
+
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -34,16 +32,23 @@ import android.view.View.MeasureSpec;
 import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
+
 import com.actionbarsherlock.R;
+import com.actionbarsherlock.TargetApi;
 import com.actionbarsherlock.internal.view.View_HasStateListenerSupport;
 import com.actionbarsherlock.internal.view.View_OnAttachStateChangeListener;
 import com.actionbarsherlock.internal.view.menu.ActionMenuView.ActionMenuChildView;
 import com.actionbarsherlock.view.ActionProvider;
 import com.actionbarsherlock.view.MenuItem;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * MenuPresenter for building action menus as seen in the action bar and action modes.
  */
+@TargetApi(TargetApi.CURRENT)
 public class ActionMenuPresenter extends BaseMenuPresenter
         implements ActionProvider.SubUiVisibilityListener {
     //UNUSED private static final String TAG = "ActionMenuPresenter";

--- a/library/src/com/actionbarsherlock/internal/view/menu/BaseMenuPresenter.java
+++ b/library/src/com/actionbarsherlock/internal/view/menu/BaseMenuPresenter.java
@@ -16,18 +16,22 @@
 
 package com.actionbarsherlock.internal.view.menu;
 
-import java.util.ArrayList;
 import android.content.Context;
 import android.os.Build;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.actionbarsherlock.TargetApi;
+
+import java.util.ArrayList;
+
 /**
  * Base class for MenuPresenters that have a consistent container view and item
  * views. Behaves similarly to an AdapterView in that existing item views will
  * be reused if possible when items change.
  */
+@TargetApi(TargetApi.CURRENT)
 public abstract class BaseMenuPresenter implements MenuPresenter {
     private static final boolean IS_HONEYCOMB = Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB;
 

--- a/library/src/com/actionbarsherlock/internal/view/menu/MenuItemWrapper.java
+++ b/library/src/com/actionbarsherlock/internal/view/menu/MenuItemWrapper.java
@@ -2,13 +2,16 @@ package com.actionbarsherlock.internal.view.menu;
 
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
-import android.view.View;
 import android.view.ContextMenu.ContextMenuInfo;
+import android.view.View;
+
+import com.actionbarsherlock.TargetApi;
 import com.actionbarsherlock.internal.view.ActionProviderWrapper;
 import com.actionbarsherlock.view.ActionProvider;
 import com.actionbarsherlock.view.MenuItem;
 import com.actionbarsherlock.view.SubMenu;
 
+@TargetApi(TargetApi.CURRENT)
 public class MenuItemWrapper implements MenuItem, android.view.MenuItem.OnMenuItemClickListener, android.view.MenuItem.OnActionExpandListener {
     private final android.view.MenuItem mNativeItem;
     private SubMenu mSubMenu = null;

--- a/library/src/com/actionbarsherlock/internal/widget/AbsActionBarView.java
+++ b/library/src/com/actionbarsherlock/internal/widget/AbsActionBarView.java
@@ -15,6 +15,8 @@
  */
 package com.actionbarsherlock.internal.widget;
 
+import static com.actionbarsherlock.internal.ResourcesCompat.getResources_getBoolean;
+
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.TypedArray;
@@ -25,6 +27,7 @@ import android.view.animation.DecelerateInterpolator;
 import android.view.animation.Interpolator;
 
 import com.actionbarsherlock.R;
+import com.actionbarsherlock.TargetApi;
 import com.actionbarsherlock.internal.nineoldandroids.animation.Animator;
 import com.actionbarsherlock.internal.nineoldandroids.animation.AnimatorSet;
 import com.actionbarsherlock.internal.nineoldandroids.animation.ObjectAnimator;
@@ -32,8 +35,7 @@ import com.actionbarsherlock.internal.nineoldandroids.view.NineViewGroup;
 import com.actionbarsherlock.internal.view.menu.ActionMenuPresenter;
 import com.actionbarsherlock.internal.view.menu.ActionMenuView;
 
-import static com.actionbarsherlock.internal.ResourcesCompat.getResources_getBoolean;
-
+@TargetApi(TargetApi.CURRENT)
 public abstract class AbsActionBarView extends NineViewGroup {
     protected ActionMenuView mMenuView;
     protected ActionMenuPresenter mActionMenuPresenter;

--- a/library/src/com/actionbarsherlock/internal/widget/ActionBarContextView.java
+++ b/library/src/com/actionbarsherlock/internal/widget/ActionBarContextView.java
@@ -29,6 +29,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.actionbarsherlock.R;
+import com.actionbarsherlock.TargetApi;
 import com.actionbarsherlock.internal.nineoldandroids.animation.Animator;
 import com.actionbarsherlock.internal.nineoldandroids.animation.Animator.AnimatorListener;
 import com.actionbarsherlock.internal.nineoldandroids.animation.AnimatorSet;
@@ -43,6 +44,7 @@ import com.actionbarsherlock.view.ActionMode;
 /**
  * @hide
  */
+@TargetApi(TargetApi.CURRENT)
 public class ActionBarContextView extends AbsActionBarView implements AnimatorListener {
     //UNUSED private static final String TAG = "ActionBarContextView";
 

--- a/library/src/com/actionbarsherlock/internal/widget/ActionBarView.java
+++ b/library/src/com/actionbarsherlock/internal/widget/ActionBarView.java
@@ -16,7 +16,8 @@
 
 package com.actionbarsherlock.internal.widget;
 
-import org.xmlpull.v1.XmlPullParser;
+import static com.actionbarsherlock.internal.ResourcesCompat.getResources_getBoolean;
+
 import android.app.Activity;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
@@ -49,6 +50,7 @@ import android.widget.SpinnerAdapter;
 import android.widget.TextView;
 
 import com.actionbarsherlock.R;
+import com.actionbarsherlock.TargetApi;
 import com.actionbarsherlock.app.ActionBar;
 import com.actionbarsherlock.app.ActionBar.OnNavigationListener;
 import com.actionbarsherlock.internal.ActionBarSherlockCompat;
@@ -65,11 +67,12 @@ import com.actionbarsherlock.view.Menu;
 import com.actionbarsherlock.view.MenuItem;
 import com.actionbarsherlock.view.Window;
 
-import static com.actionbarsherlock.internal.ResourcesCompat.getResources_getBoolean;
+import org.xmlpull.v1.XmlPullParser;
 
 /**
  * @hide
  */
+@TargetApi(TargetApi.CURRENT)
 public class ActionBarView extends AbsActionBarView {
     private static final String TAG = "ActionBarView";
     private static final boolean DEBUG = false;
@@ -1287,6 +1290,7 @@ public class ActionBarView extends AbsActionBarView {
         };
     }
 
+    @TargetApi(TargetApi.CURRENT)
     public static class HomeView extends FrameLayout {
         private View mUpView;
         private ImageView mIconView;

--- a/library/src/com/actionbarsherlock/internal/widget/CapitalizingButton.java
+++ b/library/src/com/actionbarsherlock/internal/widget/CapitalizingButton.java
@@ -1,12 +1,16 @@
 package com.actionbarsherlock.internal.widget;
 
-import java.util.Locale;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.os.Build;
 import android.util.AttributeSet;
 import android.widget.Button;
 
+import com.actionbarsherlock.TargetApi;
+
+import java.util.Locale;
+
+@TargetApi(TargetApi.CURRENT)
 public class CapitalizingButton extends Button {
     private static final boolean SANS_ICE_CREAM = Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH;
     private static final boolean IS_GINGERBREAD = Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD;

--- a/library/src/com/actionbarsherlock/internal/widget/CapitalizingTextView.java
+++ b/library/src/com/actionbarsherlock/internal/widget/CapitalizingTextView.java
@@ -1,12 +1,16 @@
 package com.actionbarsherlock.internal.widget;
 
-import java.util.Locale;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.os.Build;
 import android.util.AttributeSet;
 import android.widget.TextView;
 
+import com.actionbarsherlock.TargetApi;
+
+import java.util.Locale;
+
+@TargetApi(TargetApi.CURRENT)
 public class CapitalizingTextView extends TextView {
     private static final boolean SANS_ICE_CREAM = Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH;
     private static final boolean IS_GINGERBREAD = Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD;

--- a/library/src/com/actionbarsherlock/internal/widget/IcsLinearLayout.java
+++ b/library/src/com/actionbarsherlock/internal/widget/IcsLinearLayout.java
@@ -6,12 +6,15 @@ import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.view.View;
+
+import com.actionbarsherlock.TargetApi;
 import com.actionbarsherlock.internal.nineoldandroids.widget.NineLinearLayout;
 
 /**
  * A simple extension of a regular linear layout that supports the divider API
  * of Android 4.0+.
  */
+@TargetApi(TargetApi.CURRENT)
 public class IcsLinearLayout extends NineLinearLayout {
     private static final int[] LinearLayout = new int[] {
         /* 0 */ android.R.attr.divider,

--- a/library/src/com/actionbarsherlock/internal/widget/IcsProgressBar.java
+++ b/library/src/com/actionbarsherlock/internal/widget/IcsProgressBar.java
@@ -50,6 +50,8 @@ import android.view.animation.LinearInterpolator;
 import android.view.animation.Transformation;
 import android.widget.RemoteViews.RemoteView;
 
+import com.actionbarsherlock.TargetApi;
+
 
 /**
  * <p>
@@ -183,6 +185,7 @@ import android.widget.RemoteViews.RemoteView;
  * @attr ref android.R.styleable#ProgressBar_secondaryProgress
  */
 @RemoteView
+@TargetApi(TargetApi.CURRENT)
 public class IcsProgressBar extends View {
     private static final boolean IS_HONEYCOMB = Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB;
     private static final int MAX_LEVEL = 10000;

--- a/library/src/com/actionbarsherlock/internal/widget/ScrollingTabContainerView.java
+++ b/library/src/com/actionbarsherlock/internal/widget/ScrollingTabContainerView.java
@@ -35,7 +35,9 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.Spinner;
+
 import com.actionbarsherlock.R;
+import com.actionbarsherlock.TargetApi;
 import com.actionbarsherlock.app.ActionBar;
 import com.actionbarsherlock.internal.nineoldandroids.animation.Animator;
 import com.actionbarsherlock.internal.nineoldandroids.animation.ObjectAnimator;
@@ -44,6 +46,7 @@ import com.actionbarsherlock.internal.nineoldandroids.animation.ObjectAnimator;
  * This widget implements the dynamic action bar tab behavior that can change
  * across different configurations or circumstances.
  */
+@TargetApi(TargetApi.CURRENT)
 public class ScrollingTabContainerView extends HorizontalScrollView
         implements AdapterView.OnItemSelectedListener {
     //UNUSED private static final String TAG = "ScrollingTabContainerView";


### PR DESCRIPTION
On the next version of ADT Lint will check for usage of methods from older platforms. This is by default turned to produce an error which of course breaks ABS. Users shouldn't need to care about this.

A thing to note:

The Lint check seems to fail on anonymous classes, it will complain about usage even if the classes are marked with @TargetApi.
