### PR TITLE
Overflow menu doesn't get disabled in action mode

### DIFF
--- a/library/src/com/actionbarsherlock/internal/ActionBarSherlockCompat.java
+++ b/library/src/com/actionbarsherlock/internal/ActionBarSherlockCompat.java
@@ -318,6 +318,9 @@ public class ActionBarSherlockCompat extends ActionBarSherlock implements MenuBu
     public boolean dispatchPrepareOptionsMenu(android.view.Menu menu) {
         if (DEBUG) Log.d(TAG, "[dispatchPrepareOptionsMenu] android.view.Menu: " + menu);
 
+        if (mActionMode != null)
+            return false;
+
         mMenuIsPrepared = false;
         if (!preparePanel()) {
             return false;


### PR DESCRIPTION
The overflow menu (if any) can still be activated on 2.3 and below while in an action mode, unlike the native behavior. I've got a sample up [here](https://github.com/veeti/ABSActionModeInconsistency) and a 2-line fix that I _think_ works properly on this pull request.

Thanks for the great library!
