### PR TITLE
Supporting tabs with action modes on pre-ICS phones

### DIFF
--- a/library/src/com/actionbarsherlock/internal/widget/ScrollingTabContainerView.java
+++ b/library/src/com/actionbarsherlock/internal/widget/ScrollingTabContainerView.java
@@ -360,6 +360,14 @@ public class ScrollingTabContainerView extends HorizontalScrollView
     public void onNothingSelected(IcsAdapterView<?> parent) {
     }
 
+    public float getAlpha() {
+    	return mTabLayout.getAlpha();
+    }
+    
+    public void setAlpha(float alpha) {
+    	mTabLayout.setAlpha(alpha);
+    }
+    
     public static class TabView extends LinearLayout {
         private ScrollingTabContainerView mParent;
         private ActionBar.Tab mTab;


### PR DESCRIPTION
Alpha property setter/getter is missing from ScrollingTabContainerView. Added delegate methods to mTabLayout to solve this.
