### PR TITLE
fixes NPE ActionBar.TabListener

### DIFF
--- a/library/src/com/actionbarsherlock/internal/app/ActionBarWrapper.java
+++ b/library/src/com/actionbarsherlock/internal/app/ActionBarWrapper.java
@@ -337,8 +337,10 @@ public class ActionBarWrapper extends ActionBar implements android.app.ActionBar
             if (mListener != null) {
                 
                 if (mFragmentTransaction == null) {
-                    mFragmentTransaction = ((SherlockFragmentActivity)mActivity).getSupportFragmentManager().beginTransaction()
-                            .disallowAddToBackStack();
+                    if (mActivity instanceof SherlockFragmentActivity) {
+                        mFragmentTransaction = ((SherlockFragmentActivity)mActivity).getSupportFragmentManager().beginTransaction()
+                                .disallowAddToBackStack();
+                    }
                 }
                 
                 mListener.onTabSelected(this, mFragmentTransaction);

--- a/library/src/com/actionbarsherlock/internal/app/ActionBarWrapper.java
+++ b/library/src/com/actionbarsherlock/internal/app/ActionBarWrapper.java
@@ -335,6 +335,12 @@ public class ActionBarWrapper extends ActionBar implements android.app.ActionBar
         @Override
         public void onTabSelected(android.app.ActionBar.Tab tab, android.app.FragmentTransaction ft) {
             if (mListener != null) {
+                
+                if (mFragmentTransaction == null) {
+                    mFragmentTransaction = ((SherlockFragmentActivity)mActivity).getSupportFragmentManager().beginTransaction()
+                            .disallowAddToBackStack();
+                }
+                
                 mListener.onTabSelected(this, mFragmentTransaction);
 
                 if (mFragmentTransaction != null) {


### PR DESCRIPTION
This is a fix for Issue #391. The explanation is in the commit message.

For testing you can overwrite the FragmentTabs class in the fragment sample with the following code:

```
public class FragmentTabs extends SherlockFragmentActivity {

    ActionBar actionBar;

    @Override
    protected void onCreate(Bundle savedInstanceState) {
        setTheme(SampleList.THEME); //Used for theme switching in samples
        super.onCreate(savedInstanceState);

        actionBar = getSupportActionBar();
        actionBar.addTab(actionBar.newTab().setText("Simple")
            .setTabListener(new TabListener<FragmentStackSupport.CountingFragment>
            (this, "simple", FragmentStackSupport.CountingFragment.class)));
        actionBar.addTab(actionBar.newTab().setText("Contacts")
            .setTabListener(new TabListener<CursorLoaderListFragment>
            (this, "contacts", LoaderCursorSupport.CursorLoaderListFragment.class)));
        actionBar.addTab(actionBar.newTab().setText("Custom")
            .setTabListener(new TabListener<AppListFragment>
            (this, "custom", LoaderCustomSupport.AppListFragment.class)));
        actionBar.addTab(actionBar.newTab().setText("Throttle")
            .setTabListener(new TabListener<ThrottledLoaderListFragment>
            (this, "throttle", LoaderThrottleSupport.ThrottledLoaderListFragment.class)));
        actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_TABS);
    }

public static class TabListener<T extends Fragment> implements ActionBar.TabListener {
    private Fragment mFragment;
    private final Activity mActivity;
    private final String mTag;
    private final Class<T> mClass;

    public TabListener(Activity activity, String tag, Class<T> clz) {
        mActivity = activity;
        mTag = tag;
        mClass = clz;
    }

    public void onTabSelected(Tab tab, FragmentTransaction ft) {
        if (ft == null) {
             Log.i("tabselected", "fragmenttransaction == null");
             return;
        }
        if (mFragment == null) {
            mFragment = Fragment.instantiate(mActivity, mClass.getName());
            ft.add(android.R.id.content, mFragment, mTag);
        } else {
            ft.attach(mFragment);
        }
    }

    public void onTabUnselected(Tab tab, FragmentTransaction ft) {
        if (ft == null) {
            Log.i("tabunselected", "fragmenttransaction == null");
                return;
        }
        if (mFragment != null) {
            ft.detach(mFragment);
        }
    }

    public void onTabReselected(Tab tab, FragmentTransaction ft) {
    }
}
}
```
