### PR TITLE
Removed unnecessary Runnable field

### DIFF
--- a/library/src/com/actionbarsherlock/internal/widget/ActionBarView.java
+++ b/library/src/com/actionbarsherlock/internal/widget/ActionBarView.java
@@ -132,8 +132,6 @@ public class ActionBarView extends AbsActionBarView {
     private SpinnerAdapter mSpinnerAdapter;
     private OnNavigationListener mCallback;
 
-    private Runnable mTabSelector;
-
     private ExpandedActionViewMenuPresenter mExpandedMenuPresenter;
     View mExpandedActionView;
 
@@ -383,7 +381,6 @@ public class ActionBarView extends AbsActionBarView {
     @Override
     public void onDetachedFromWindow() {
         super.onDetachedFromWindow();
-        removeCallbacks(mTabSelector);
         if (mActionMenuPresenter != null) {
             mActionMenuPresenter.hideOverflowMenu();
             mActionMenuPresenter.hideSubMenus();

--- a/library/src/com/actionbarsherlock/internal/widget/ActionBarView.java
+++ b/library/src/com/actionbarsherlock/internal/widget/ActionBarView.java
@@ -132,6 +132,8 @@ public class ActionBarView extends AbsActionBarView {
     private SpinnerAdapter mSpinnerAdapter;
     private OnNavigationListener mCallback;
 
+    //UNUSED private Runnable mTabSelector;
+
     private ExpandedActionViewMenuPresenter mExpandedMenuPresenter;
     View mExpandedActionView;
 
@@ -381,6 +383,7 @@ public class ActionBarView extends AbsActionBarView {
     @Override
     public void onDetachedFromWindow() {
         super.onDetachedFromWindow();
+        //UNUSED removeCallbacks(mTabSelector);
         if (mActionMenuPresenter != null) {
             mActionMenuPresenter.hideOverflowMenu();
             mActionMenuPresenter.hideSubMenus();


### PR DESCRIPTION
`mTabSelector` field (`Runnable`) is never assigned.
