### PR TITLE
Fixes typo in ActionBarSherlock / website / resources / migration.html

### DIFF
--- a/website/resources/migration.html
+++ b/website/resources/migration.html
@@ -32,7 +32,7 @@ layout: default
 		<h2>Methods</h2>
 		<p>Very few APIs have actually changed between versions. There are only two which you should be aware of:</p>
 		<ul>
-			<li><code>getSherlockActivity()</code> in any base fragment. This returns an instance of you activity that has already been case to <code>SherlockFragmentActivity</code>.
+			<li><code>getSherlockActivity()</code> in any base fragment. This returns an instance of you activity that has already been cast to <code>SherlockFragmentActivity</code>.
 			<li><code>getSherlock()</code> in any base activity. This will allow access to the <code>ActionBarSherlock</code> interface which allows for interaction with all of the features of the library. Normally you would not need access to this unless you want to programmatically set the activity's UI options.</li>
 		</ul>
 


### PR DESCRIPTION
"case" was replaced by "cast" in the sentence below:

getSherlockActivity() in any base fragment. This returns an instance of you activity that has already been _case_ to SherlockFragmentActivity.
