### PR TITLE
IcsLinearLayout lacks a getter/setter for padding

### DIFF
--- a/library/src/com/actionbarsherlock/internal/widget/IcsLinearLayout.java
+++ b/library/src/com/actionbarsherlock/internal/widget/IcsLinearLayout.java
@@ -107,6 +107,21 @@ public class IcsLinearLayout extends NineLinearLayout {
     }
 
     /**
+     * Set padding displayed on both ends of dividers.
+     * @param padding Padding value in pixels that will be applied to each end.
+     */
+    public void setDividerPadding (int padding) {
+        mDividerPadding=padding;
+    }
+
+    /**
+     * Get the padding size used to inset dividers in pixels.
+     */
+    public int getDividerPadding() {
+        return mDividerPadding;
+    }
+
+    /**
      * Get the width of the current divider drawable.
      *
      * @hide Used internally by framework.


### PR DESCRIPTION
I intend on using IcsLinearLayout in my application, and thought I'd add these methods while I was at it; would prefer it to be in your sources.
