### PR TITLE
Declare support-library as provided in ActionBarSherlock-library

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -24,6 +24,7 @@
 		<dependency>
 			<groupId>com.google.android</groupId>
 			<artifactId>support-v4</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>

--- a/samples/demos/pom.xml
+++ b/samples/demos/pom.xml
@@ -23,6 +23,10 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.google.android</groupId>
+			<artifactId>support-v4</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.actionbarsherlock</groupId>
 			<artifactId>library</artifactId>
 			<version>${project.version}</version>

--- a/samples/fragments/pom.xml
+++ b/samples/fragments/pom.xml
@@ -23,6 +23,10 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.google.android</groupId>
+			<artifactId>support-v4</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.actionbarsherlock</groupId>
 			<artifactId>library</artifactId>
 			<version>${project.version}</version>

--- a/samples/roboguice/pom.xml
+++ b/samples/roboguice/pom.xml
@@ -23,6 +23,10 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.google.android</groupId>
+			<artifactId>support-v4</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.actionbarsherlock</groupId>
 			<artifactId>library</artifactId>
 			<version>${project.version}</version>

--- a/samples/styled/pom.xml
+++ b/samples/styled/pom.xml
@@ -23,6 +23,10 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.google.android</groupId>
+			<artifactId>support-v4</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.actionbarsherlock</groupId>
 			<artifactId>library</artifactId>
 			<version>${project.version}</version>


### PR DESCRIPTION
Would it make sense to mark the support-library as provided in the ActionBarSherlock library pom? That way every application could decide which support-library to use.

In my case that would be a library which uses MapActivity as super class for FragmentActivity, because I want to display fragments and a Google-Maps map in an activity.

I've already seen, that your ViewPagerIndicator library (which is also used in that application) also declares the support-library as provided.
