### PR TITLE
Return early when current index is 0

### DIFF
--- a/library/src/com/actionbarsherlock/internal/view/menu/ActionMenuView.java
+++ b/library/src/com/actionbarsherlock/internal/view/menu/ActionMenuView.java
@@ -520,6 +520,8 @@ public class ActionMenuView extends IcsLinearLayout implements MenuBuilder.ItemI
 
     //@Override
     protected boolean hasDividerBeforeChildAt(int childIndex) {
+        if (childIndex == 0)
+            return false;
         final View childBefore = getChildAt(childIndex - 1);
         final View child = getChildAt(childIndex);
         boolean result = false;


### PR DESCRIPTION
On Gingerbread and possibly older versions of Android
ViewGroup.getChildAt would catch an exception when a
invalid index was requested.

Adding a guard at this layer prevents many exceptions
from being allocated and thrown away at the ViewGroup
layer.

https://github.com/android/platform_frameworks_base/blob/android-2.2_r1/core/java/android/view/ViewGroup.java#L3057
