### PR TITLE
Fix dropdown selection when navigating to tab using getSupportActionBar().selectTab(tab);

### DIFF
--- a/library/src/com/actionbarsherlock/internal/widget/ScrollingTabContainerView.java
+++ b/library/src/com/actionbarsherlock/internal/widget/ScrollingTabContainerView.java
@@ -178,6 +178,8 @@ public class ScrollingTabContainerView extends NineHorizontalScrollView
                 animateToTab(position);
             }
         }
+        if(mTabSpinner != null)
+            mTabSpinner.setSelection(position);
     }
 
     public void setContentHeight(int contentHeight) {


### PR DESCRIPTION
This fixes a problem with tabbed navigation (ActionBar.NAVIGATION_MODE_TABS) when the tabs have been collapsed into a dropdown menu.  Currently, programmatically navigating to a tab using getSupportActionBar().selectTab(tab) does not correctly set the selected item on the dropdown.  The previous tab title remains displayed, and the UI is left in an inconsistent state where the actual tab does not correspond to the tab selected in the dropdown.
