### PR TITLE
android-support-v4.jar removed from apklib

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -47,6 +47,9 @@
 				<groupId>com.jayway.maven.plugins.android.generation2</groupId>
 				<artifactId>android-maven-plugin</artifactId>
 				<extensions>true</extensions>
+				<configuration>
+					<nativeLibrariesDirectory>ignored</nativeLibrariesDirectory>
+				</configuration>
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
android-support-v4.jar from libs folder makes problems in Idea IDE. It's unnecessary for projects using maven, so can be safely removed from apklib package
