### PR TITLE
FragmentTransaction is null for non-sherlock activities

### DIFF
--- a/library/src/com/actionbarsherlock/internal/app/ActionBarImpl.java
+++ b/library/src/com/actionbarsherlock/internal/app/ActionBarImpl.java
@@ -37,7 +37,6 @@ import android.view.accessibility.AccessibilityEvent;
 import android.widget.SpinnerAdapter;
 import com.actionbarsherlock.R;
 import com.actionbarsherlock.app.ActionBar;
-import com.actionbarsherlock.app.SherlockFragmentActivity;
 import com.actionbarsherlock.internal.nineoldandroids.animation.Animator;
 import com.actionbarsherlock.internal.nineoldandroids.animation.AnimatorListenerAdapter;
 import com.actionbarsherlock.internal.nineoldandroids.animation.AnimatorSet;

--- a/library/src/com/actionbarsherlock/internal/app/ActionBarImpl.java
+++ b/library/src/com/actionbarsherlock/internal/app/ActionBarImpl.java
@@ -26,6 +26,7 @@ import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Handler;
+import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentTransaction;
 import android.util.TypedValue;
 import android.view.ContextThemeWrapper;
@@ -506,8 +507,8 @@ public class ActionBarImpl extends ActionBar {
         }
 
         FragmentTransaction trans = null;
-        if (mActivity instanceof SherlockFragmentActivity) {
-            trans = ((SherlockFragmentActivity)mActivity).getSupportFragmentManager().beginTransaction()
+        if (mActivity instanceof FragmentActivity) {
+            trans = ((FragmentActivity)mActivity).getSupportFragmentManager().beginTransaction()
                     .disallowAddToBackStack();
         }
 

--- a/library/src/com/actionbarsherlock/internal/app/ActionBarWrapper.java
+++ b/library/src/com/actionbarsherlock/internal/app/ActionBarWrapper.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
+import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentTransaction;
 import android.view.View;
 import android.widget.SpinnerAdapter;
@@ -319,10 +320,10 @@ public class ActionBarWrapper extends ActionBar implements android.app.ActionBar
         public void onTabReselected(android.app.ActionBar.Tab tab, android.app.FragmentTransaction ft) {
             if (mListener != null) {
                 FragmentTransaction trans = null;
-                if (mActivity instanceof SherlockFragmentActivity) {
-                    trans = ((SherlockFragmentActivity)mActivity).getSupportFragmentManager().beginTransaction()
-                            .disallowAddToBackStack();
-                }
+		        if (mActivity instanceof FragmentActivity) {
+		            trans = ((FragmentActivity)mActivity).getSupportFragmentManager().beginTransaction()
+		                    .disallowAddToBackStack();
+		        }
 
                 mListener.onTabReselected(this, trans);
 
@@ -336,8 +337,8 @@ public class ActionBarWrapper extends ActionBar implements android.app.ActionBar
         public void onTabSelected(android.app.ActionBar.Tab tab, android.app.FragmentTransaction ft) {
             if (mListener != null) {
 
-                if (mFragmentTransaction == null && mActivity instanceof SherlockFragmentActivity) {
-                    mFragmentTransaction = ((SherlockFragmentActivity)mActivity).getSupportFragmentManager().beginTransaction()
+                if (mFragmentTransaction == null && mActivity instanceof FragmentActivity) {
+                    mFragmentTransaction = ((FragmentActivity)mActivity).getSupportFragmentManager().beginTransaction()
                             .disallowAddToBackStack();
                 }
 
@@ -356,8 +357,8 @@ public class ActionBarWrapper extends ActionBar implements android.app.ActionBar
         public void onTabUnselected(android.app.ActionBar.Tab tab, android.app.FragmentTransaction ft) {
             if (mListener != null) {
                 FragmentTransaction trans = null;
-                if (mActivity instanceof SherlockFragmentActivity) {
-                    trans = ((SherlockFragmentActivity)mActivity).getSupportFragmentManager().beginTransaction()
+                if (mActivity instanceof FragmentActivity) {
+                    trans = ((FragmentActivity)mActivity).getSupportFragmentManager().beginTransaction()
                             .disallowAddToBackStack();
                     mFragmentTransaction = trans;
                 }

--- a/library/src/com/actionbarsherlock/internal/app/ActionBarWrapper.java
+++ b/library/src/com/actionbarsherlock/internal/app/ActionBarWrapper.java
@@ -12,7 +12,6 @@ import android.view.View;
 import android.widget.SpinnerAdapter;
 
 import com.actionbarsherlock.app.ActionBar;
-import com.actionbarsherlock.app.SherlockFragmentActivity;
 
 public class ActionBarWrapper extends ActionBar implements android.app.ActionBar.OnNavigationListener, android.app.ActionBar.OnMenuVisibilityListener {
     private final Activity mActivity;
@@ -320,10 +319,10 @@ public class ActionBarWrapper extends ActionBar implements android.app.ActionBar
         public void onTabReselected(android.app.ActionBar.Tab tab, android.app.FragmentTransaction ft) {
             if (mListener != null) {
                 FragmentTransaction trans = null;
-		        if (mActivity instanceof FragmentActivity) {
-		            trans = ((FragmentActivity)mActivity).getSupportFragmentManager().beginTransaction()
-		                    .disallowAddToBackStack();
-		        }
+                if (mActivity instanceof FragmentActivity) {
+                    trans = ((FragmentActivity)mActivity).getSupportFragmentManager().beginTransaction()
+                            .disallowAddToBackStack();
+                }
 
                 mListener.onTabReselected(this, trans);
 


### PR DESCRIPTION
Sherlock is passing FragmentTransaction instance in tab callbacks now(since v4). But there is strange instance class check here [ActionBarImpl.java:509](https://github.com/JakeWharton/ActionBarSherlock/blob/master/library/src/com/actionbarsherlock/internal/app/ActionBarImpl.java#L509) and here [ActionBarWrapper.java:322](https://github.com/JakeWharton/ActionBarSherlock/blob/master/library/src/com/actionbarsherlock/internal/app/ActionBarWrapper.java#L322).

There is no point to do that check because you can just use FragmentActivity and obtain FragmentManager:

``` java
        if (mActivity instanceof FragmentActivity) {
            trans = ((FragmentActivity)mActivity).getSupportFragmentManager().beginTransaction()
                    .disallowAddToBackStack();
        }
```
