### PR TITLE
Reflect update of the library to 4.1.0 on the usage page

### DIFF
--- a/website/usage.html
+++ b/website/usage.html
@@ -25,7 +25,7 @@ layout: default
 &lt;dependency>
   &lt;groupId>com.actionbarsherlock&lt;/groupId>
   &lt;artifactId>library&lt;/artifactId>
-  &lt;version><span class="latest-version">4.0.0</span>&lt;/version>
+  &lt;version><span class="latest-version">4.1.0</span>&lt;/version>
   &lt;type>apklib&lt;/type>
 &lt;/dependency>
 </pre></code>


### PR DESCRIPTION
Let's people who have only gone to the website to figure out the maven import get all those nice fixes that've been added to the library since 4.0
