### PR TITLE
Preserve tab behavior onOrientationChange (issue #365)

### DIFF
--- a/library/src/com/actionbarsherlock/internal/app/ActionBarImpl.java
+++ b/library/src/com/actionbarsherlock/internal/app/ActionBarImpl.java
@@ -187,6 +187,7 @@ public class ActionBarImpl extends ActionBar {
                 mContextView.onConfigurationChanged(newConfig);
             }
         }
+        recreateTabs();
     }
 
     private void setHasEmbeddedTabs(boolean hasEmbeddedTabs) {
@@ -338,6 +339,25 @@ public class ActionBarImpl extends ActionBar {
             mTabScrollView.removeAllTabs();
         }
         mSavedTabPosition = INVALID_POSITION;
+    }
+
+    private void recreateTabs() {
+        if(mTabScrollView == null) {
+            return;
+        }
+        ArrayList<TabImpl> tabs = new ArrayList<TabImpl>(mTabs);
+        int tabPosition = getSelectedNavigationIndex();
+        cleanupTabs();
+        mTabScrollView.onDetachedFromWindow();
+        mTabScrollView = null;
+        ensureTabsExist();
+        for(ActionBar.Tab tab : tabs) {
+            addTab(tab, false);
+        }
+        if(tabPosition != INVALID_POSITION) {
+            selectTab(tabs.get(tabPosition));
+        }
+
     }
 
     public void setTitle(CharSequence title) {


### PR DESCRIPTION
This commit fixes tab behavior bug onOrientationChange when Activity handles orientation changes (android:configChanges="orientation").

Probably, this is not the proper implementation because it re-creates tab layout but for our case, it solves the problem.
Tested on Android 2.3.4 and Android 4.0.4.
