### PR TITLE
Fix for issue #564

### DIFF
--- a/library/src/com/actionbarsherlock/internal/ResourcesCompat.java
+++ b/library/src/com/actionbarsherlock/internal/ResourcesCompat.java
@@ -25,36 +25,40 @@ public final class ResourcesCompat {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR2) {
             return context.getResources().getBoolean(id);
         }
+        
+	try {
+	    DisplayMetrics metrics = context.getResources().getDisplayMetrics();
+	    float widthDp = metrics.widthPixels / metrics.density;
+	    float heightDp = metrics.heightPixels / metrics.density;
+	    float smallestWidthDp = (widthDp < heightDp) ? widthDp : heightDp;
 
-        DisplayMetrics metrics = context.getResources().getDisplayMetrics();
-        float widthDp = metrics.widthPixels / metrics.density;
-        float heightDp = metrics.heightPixels / metrics.density;
-        float smallestWidthDp = (widthDp < heightDp) ? widthDp : heightDp;
-
-        if (id == R.bool.abs__action_bar_embed_tabs) {
-            if (widthDp >= 480) {
-                return true; //values-w480dp
-            }
-            return false; //values
-        }
-        if (id == R.bool.abs__split_action_bar_is_narrow) {
-            if (widthDp >= 480) {
-                return false; //values-w480dp
-            }
-            return true; //values
-        }
-        if (id == R.bool.abs__action_bar_expanded_action_views_exclusive) {
-            if (smallestWidthDp >= 600) {
-                return false; //values-sw600dp
-            }
-            return true; //values
-        }
-        if (id == R.bool.abs__config_allowActionMenuItemTextWithIcon) {
-            if (widthDp >= 480) {
-                return true; //values-w480dp
-            }
-            return false; //values
-        }
+	    if (id == R.bool.abs__action_bar_embed_tabs) {
+		if (widthDp >= 480) {
+		    return true; // values-w480dp
+		}
+		return false; // values
+	    }
+	    if (id == R.bool.abs__split_action_bar_is_narrow) {
+		if (widthDp >= 480) {
+		    return false; // values-w480dp
+		}
+		return true; // values
+	    }
+	    if (id == R.bool.abs__action_bar_expanded_action_views_exclusive) {
+		if (smallestWidthDp >= 600) {
+		    return false; // values-sw600dp
+		}
+		return true; // values
+	    }
+	    if (id == R.bool.abs__config_allowActionMenuItemTextWithIcon) {
+		if (widthDp >= 480) {
+		    return true; // values-w480dp
+		}
+		return false; // values
+	    }
+	} catch (ArrayIndexOutOfBoundsException ex) {
+	    return context.getResources().getBoolean(id);
+	}
 
         throw new IllegalArgumentException("Unknown boolean resource ID " + id);
     }


### PR DESCRIPTION
Issue appeared when a lot of UI tests which used Robotium were running one after another on Jenkins. When getResources_getBoolean() method from ResourcesCompat.java was surrounded with try catch block, issue disappeared.  
Not sure what was causing that ArrayIndexOfBoundsException. Probably internal Robotium logic of initializing and finishing test activities. Sometimes they are not finished correctly and keep hanging in memory.
Or, probably, ActionBarSherlock's options menu was not initializing correctly in some cases.
