### PR TITLE
Fix: bad version range for maven-replace-plugin Eclipse lifecycle exclusion.

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -3,7 +3,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.actionbarsherlock</groupId>
 	<artifactId>library</artifactId>
 	<name>ActionBarSherlock</name>
 	<packaging>apklib</packaging>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -23,7 +23,6 @@
 		<dependency>
 			<groupId>com.google.android</groupId>
 			<artifactId>support-v4</artifactId>
-			<scope>provided</scope>
 		</dependency>
 
 		<dependency>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -23,6 +23,7 @@
 		<dependency>
 			<groupId>com.google.android</groupId>
 			<artifactId>support-v4</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -132,7 +132,7 @@
 									<pluginExecutionFilter>
 										<groupId>com.google.code.maven-replacer-plugin</groupId>
 										<artifactId>maven-replacer-plugin</artifactId>
-										<versionRange>[1.4.1,)</versionRange>
+										<versionRange>[1.4.0,)</versionRange>
 										<goals>
 											<goal>replace</goal>
 										</goals>


### PR DESCRIPTION
Just a small fix: Eclipse lifecycle mapping exclusion does not match version of maven-replace-plugin causing build errors in Eclipse m2e.
