### PR TITLE
fix issue #565

### DIFF
--- a/library/res/values-v14/abs__styles.xml
+++ b/library/res/values-v14/abs__styles.xml
@@ -85,6 +85,11 @@
     <style name="Widget.Sherlock.Light.ProgressBar.Horizontal" parent="android:Widget.Holo.Light.ProgressBar.Horizontal">
     </style>
 
+    <style name="Widget.Sherlock.AutoCompleteTextView" parent="android:Widget.Holo.AutoCompleteTextView">
+    </style>
+    <style name="Widget.Sherlock.Light.AutoCompleteTextView" parent="android:Widget.Holo.Light.AutoCompleteTextView">
+    </style>
+
     <style name="TextAppearance.Sherlock.Widget.ActionBar.Menu" parent="android:TextAppearance.Holo.Widget.ActionBar.Menu">
     </style>
 

--- a/library/res/values/abs__styles.xml
+++ b/library/res/values/abs__styles.xml
@@ -280,7 +280,7 @@
 
 
 
-    <style name="Sherlock.__Widget.AutoCompleteTextView" parent="Widget">
+    <style name="Sherlock.__Widget.AutoCompleteTextView" parent="@android:style/Widget.EditText">
         <item name="android:focusable">true</item>
         <item name="android:focusableInTouchMode">true</item>
         <item name="android:clickable">true</item>

--- a/library/res/values/abs__styles.xml
+++ b/library/res/values/abs__styles.xml
@@ -280,7 +280,7 @@
 
 
 
-    <style name="Sherlock.__Widget.AutoCompleteTextView" parent="@android:style/Widget.EditText">
+    <style name="Sherlock.__Widget.AutoCompleteTextView" parent="android:Widget.EditText">
         <item name="android:focusable">true</item>
         <item name="android:focusableInTouchMode">true</item>
         <item name="android:clickable">true</item>


### PR DESCRIPTION
Use "@android:style/Widget.EditText" instead of Widget as parent for AutoCompleteTextView style, to solve issue #565. As pointed out there in ICS the stock style uses it too as parent. I tested in on Gingerbread, Honeycomb and ICS (level 10,13,15) and it works.
