### PR TITLE
Issue #510

### DIFF
--- a/samples/known-bugs/res/layout/issue510.xml
+++ b/samples/known-bugs/res/layout/issue510.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" >
+    
+    <fragment class="com.actionbarsherlock.sample.knownbugs.Issue510Fragment"
+        android:id="@+id/frag"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+</FrameLayout>

--- a/samples/known-bugs/res/layout/issue510_fragment.xml
+++ b/samples/known-bugs/res/layout/issue510_fragment.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" >
+    
+</FrameLayout>

--- a/samples/known-bugs/res/menu/issue510.xml
+++ b/samples/known-bugs/res/menu/issue510.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:id="@+id/menuItem1" android:icon="@drawable/ic_refresh" android:title="cannot click on gingerbread" android:showAsAction="ifRoom|withText" />
+
+</menu>

--- a/samples/known-bugs/src/com/actionbarsherlock/sample/knownbugs/Issue510.java
+++ b/samples/known-bugs/src/com/actionbarsherlock/sample/knownbugs/Issue510.java
@@ -1,0 +1,32 @@
+package com.actionbarsherlock.sample.knownbugs;
+
+import android.os.Bundle;
+
+import com.actionbarsherlock.app.ActionBar;
+import com.actionbarsherlock.app.SherlockFragmentActivity;
+import com.actionbarsherlock.view.Menu;
+
+public class Issue510 extends SherlockFragmentActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.issue510);
+
+        ActionBar bar = getSupportActionBar();
+
+        // Attach to the action bar
+        bar.setHomeButtonEnabled(true);
+        bar.setDisplayShowHomeEnabled(true);
+        bar.setDisplayHomeAsUpEnabled(true);
+        bar.setDisplayShowTitleEnabled(true);
+
+        invalidateOptionsMenu();
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        return true;
+    }
+
+}

--- a/samples/known-bugs/src/com/actionbarsherlock/sample/knownbugs/Issue510Fragment.java
+++ b/samples/known-bugs/src/com/actionbarsherlock/sample/knownbugs/Issue510Fragment.java
@@ -1,0 +1,49 @@
+package com.actionbarsherlock.sample.knownbugs;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toast;
+
+import com.actionbarsherlock.app.SherlockFragment;
+import com.actionbarsherlock.view.Menu;
+import com.actionbarsherlock.view.MenuInflater;
+import com.actionbarsherlock.view.MenuItem;
+
+public class Issue510Fragment extends SherlockFragment {
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.issue510_fragment, null);
+        return view;
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        setHasOptionsMenu(true);
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        inflater.inflate(R.menu.issue510, menu);
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        // probably making changes depending on data
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+        case R.id.menuItem1:
+            Toast.makeText(getActivity(), item.getTitle(), Toast.LENGTH_SHORT).show();
+            return true;
+        default:
+            return super.onOptionsItemSelected(item);
+        }
+    }
+
+}


### PR DESCRIPTION
Here is the test case. I found out that you may not call invalidateOptionsMenu() within SherlockFragmentActivity.onCreate(..).

P.S.: This is my first pull request. Hope I did everything right.
