### PR TITLE
Added support for transparent holo themes which were missing

### DIFF
--- a/library/res/values/abs__themes.xml
+++ b/library/res/values/abs__themes.xml
@@ -182,6 +182,23 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>
+    <style name="Theme.Sherlock.Translucent">
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:colorBackgroundCacheHint">@null</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <!-- Note that we use the base animation style here (that is no
+             animations) because we really have no idea how this kind of
+             activity will be used. -->
+        <item name="android:windowAnimationStyle">@android:style/Animation</item>
+    </style>
+    <style name="Theme.Sherlock.Translucent.NoTitleBar">
+        <item name="android:windowActionBar">false</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowContentOverlay">@null</item>
+    </style>
+    <style name="Theme.Sherlock.Translucent.NoTitleBar.Fullscreen">
+        <item name="android:windowFullscreen">true</item>
+    </style>
 
 
     <style name="Theme.Sherlock.Dialog" parent="android:Theme">


### PR DESCRIPTION
The only available translucent theme on Android (and therefore in ActionbarSherlock) is :

```
@android:style/Theme.Translucent.NoTitleBar
```

The problem with this theme is that any component added to an Activity which has this theme, will be styled with a Gingerbread UI.

This commit adds 3 themes to ActionbarSherlock :

```
Theme.Sherlock.Translucent
Theme.Sherlock.Translucent.NoTitleBar
Theme.Sherlock.Translucent.NoTitleBar.Fullscreen
```
