### PR TITLE
Fix #652 NPE on sdk < Honeycomb

### DIFF
--- a/library/src/com/actionbarsherlock/internal/view/menu/MenuBuilder.java
+++ b/library/src/com/actionbarsherlock/internal/view/menu/MenuBuilder.java
@@ -31,6 +31,7 @@ import android.content.pm.ResolveInfo;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.util.SparseArray;
@@ -353,6 +354,11 @@ public class MenuBuilder implements Menu {
         SparseArray<Parcelable> viewStates = states.getSparseParcelableArray(
                 getActionViewStatesKey());
 
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB && viewStates == null){
+        	//Fixes Issue #652 with sdk <= 2.3.6
+        	return;
+        }
+        
         final int itemCount = size();
         for (int i = 0; i < itemCount; i++) {
             final MenuItem item = getItem(i);

--- a/library/src/com/actionbarsherlock/internal/view/menu/MenuBuilder.java
+++ b/library/src/com/actionbarsherlock/internal/view/menu/MenuBuilder.java
@@ -355,10 +355,10 @@ public class MenuBuilder implements Menu {
                 getActionViewStatesKey());
 
         if(Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB && viewStates == null){
-        	//Fixes Issue #652 with sdk <= 2.3.6
-        	return;
+            //Fixes Issue #652 with sdk <= 2.3.6
+            return;
         }
-        
+
         final int itemCount = size();
         for (int i = 0; i < itemCount; i++) {
             final MenuItem item = getItem(i);


### PR DESCRIPTION
Calling dispatchRestoreInstanceState from ABS on pre honeycomb causes View.java to throw a NPE sometimes becuase ViewGroup.java doesn't do this check in the older versions. This bug doesn't appear in newer versions of the framework.

``` java
if ((c.mViewFlags & PARENT_SAVE_DISABLED_MASK) != PARENT_SAVE_DISABLED)
{
    c.dispatchRestoreInstanceState(container);
}
```

View.java doesn't check for a null container (even on JB) in
dispatchRestoreInstanceState so it just blows up.

ref #652
