### PR TITLE
changed provider authority so it doesn't conflict with support v4 demos

### DIFF
--- a/samples/fragments/AndroidManifest.xml
+++ b/samples/fragments/AndroidManifest.xml
@@ -159,6 +159,6 @@
             </intent-filter>
         </activity>
 
-        <provider android:authorities="com.example.android.apis.supportv4.app.LoaderThrottle" android:name=".LoaderThrottleSupport$SimpleProvider"/>
+        <provider android:authorities="com.actionbarsherlock.sample.fragments.LoaderThrottle" android:name=".LoaderThrottleSupport$SimpleProvider"/>
     </application>
 </manifest>

--- a/samples/fragments/src/com/actionbarsherlock/sample/fragments/LoaderThrottleSupport.java
+++ b/samples/fragments/src/com/actionbarsherlock/sample/fragments/LoaderThrottleSupport.java
@@ -61,7 +61,7 @@ public class LoaderThrottleSupport extends SherlockFragmentActivity {
     /**
      * The authority we use to get to our sample provider.
      */
-    public static final String AUTHORITY = "com.example.android.apis.supportv4.app.LoaderThrottle";
+    public static final String AUTHORITY = "com.actionbarsherlock.sample.fragments.LoaderThrottle";
 
     /**
      * Definition of the contract for the main table of our provider.


### PR DESCRIPTION
so the fragments sample app and the official support v4 demos app can play nicely together (resolves `INSTALL_FAILED_CONFLICTING_PROVIDER`).
