### PR TITLE
Re-add ABS support for GTV menu button

### DIFF
--- a/library/src/com/actionbarsherlock/internal/ActionBarSherlockCompat.java
+++ b/library/src/com/actionbarsherlock/internal/ActionBarSherlockCompat.java
@@ -72,6 +72,8 @@ public class ActionBarSherlockCompat extends ActionBarSherlock implements MenuBu
     private MenuBuilder mMenu;
     /** Map between native options items and sherlock items. */
     protected HashMap<android.view.MenuItem, MenuItemImpl> mNativeItemMap;
+    /** Indication of a long-press on the hardware menu key. */
+    private boolean mMenuKeyIsLongPress = false;
 
     /** Parent view of the window decoration (action bar, mode, etc.). */
     private ViewGroup mDecor;
@@ -426,8 +428,34 @@ public class ActionBarSherlockCompat extends ActionBarSherlock implements MenuBu
             }
         }
 
-        if (DEBUG) Log.d(TAG, "[dispatchKeyEvent] returning false");
-        return false;
+        boolean result = false;
+        boolean isGoogleTV = false;
+        if (mActivity != null) {
+            isGoogleTV =  mActivity.getPackageManager().hasSystemFeature("com.google.android.tv");
+        }
+
+        if (isGoogleTV) {
+            if (keyCode == KeyEvent.KEYCODE_MENU && isReservingOverflow()) {
+                if (event.getAction() == KeyEvent.ACTION_DOWN && event.isLongPress()) {
+                    mMenuKeyIsLongPress = true;
+                } else if (event.getAction() == KeyEvent.ACTION_UP) {
+                    if (!mMenuKeyIsLongPress) {
+                        if (mActionMode == null && wActionBar != null) {
+                            if (wActionBar.isOverflowMenuShowing()) {
+                                wActionBar.hideOverflowMenu();
+                            } else {
+                                wActionBar.showOverflowMenu();
+                            }
+                        }
+                        result = true;
+                    }
+                    mMenuKeyIsLongPress = false;
+                }
+            }
+        }
+
+        if (DEBUG) Log.d(TAG, "[dispatchKeyEvent] returning " + result);
+        return result;
     }
 
     @Override


### PR DESCRIPTION
This patch restores functionality to show overflow menu when the menu button is pressed, but only on GTV systems.
