### PR TITLE
Init the action bar during findViewById

### DIFF
--- a/library/src/com/actionbarsherlock/ActionBarSherlock.java
+++ b/library/src/com/actionbarsherlock/ActionBarSherlock.java
@@ -791,4 +791,9 @@ public abstract class ActionBarSherlock {
      * @see ActionMode
      */
     public abstract ActionMode startActionMode(ActionMode.Callback callback);
+
+    /**
+     * Ensure that the action bar is attached.
+     */
+    public void ensureActionBar() {}
 }

--- a/library/src/com/actionbarsherlock/app/SherlockActivity.java
+++ b/library/src/com/actionbarsherlock/app/SherlockActivity.java
@@ -243,6 +243,12 @@ public abstract class SherlockActivity extends Activity implements OnCreatePanel
         getSherlock().requestFeature((int)featureId);
     }
 
+    @Override
+    public View findViewById(int id) {
+        getSherlock().ensureActionBar();
+        return super.findViewById(id);
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////
     // Progress Indication

--- a/library/src/com/actionbarsherlock/app/SherlockExpandableListActivity.java
+++ b/library/src/com/actionbarsherlock/app/SherlockExpandableListActivity.java
@@ -232,6 +232,12 @@ public abstract class SherlockExpandableListActivity extends ExpandableListActiv
         getSherlock().requestFeature((int)featureId);
     }
 
+    @Override
+    public View findViewById(int id) {
+        getSherlock().ensureActionBar();
+        return super.findViewById(id);
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////
     // Progress Indication

--- a/library/src/com/actionbarsherlock/app/SherlockFragmentActivity.java
+++ b/library/src/com/actionbarsherlock/app/SherlockFragmentActivity.java
@@ -276,6 +276,12 @@ public class SherlockFragmentActivity extends Watson implements OnActionModeStar
         getSherlock().requestFeature((int)featureId);
     }
 
+    @Override
+    public View findViewById(int id) {
+        getSherlock().ensureActionBar();
+        return super.findViewById(id);
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////
     // Progress Indication

--- a/library/src/com/actionbarsherlock/app/SherlockListActivity.java
+++ b/library/src/com/actionbarsherlock/app/SherlockListActivity.java
@@ -243,6 +243,12 @@ public abstract class SherlockListActivity extends ListActivity implements OnCre
         getSherlock().requestFeature((int)featureId);
     }
 
+    @Override
+    public View findViewById(int id) {
+        getSherlock().ensureActionBar();
+        return super.findViewById(id);
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////
     // Progress Indication

--- a/library/src/com/actionbarsherlock/app/SherlockPreferenceActivity.java
+++ b/library/src/com/actionbarsherlock/app/SherlockPreferenceActivity.java
@@ -243,6 +243,12 @@ public abstract class SherlockPreferenceActivity extends PreferenceActivity impl
         getSherlock().requestFeature((int)featureId);
     }
 
+    @Override
+    public View findViewById(int id) {
+        getSherlock().ensureActionBar();
+        return super.findViewById(id);
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////
     // Progress Indication

--- a/library/src/com/actionbarsherlock/internal/ActionBarSherlockCompat.java
+++ b/library/src/com/actionbarsherlock/internal/ActionBarSherlockCompat.java
@@ -1200,4 +1200,13 @@ public class ActionBarSherlockCompat extends ActionBarSherlock implements MenuBu
             mActionMode = null;
         }
     }
+
+    @Override
+    public void ensureActionBar() {
+        if (DEBUG) Log.d(TAG, "[ensureActionBar]");
+
+        if (mDecor == null) {
+            initActionBar();
+        }
+    }
 }


### PR DESCRIPTION
Ensure that the ActionBar is initialized when findViewById is called.

Closes #623 and #748.
