### PR TITLE
i18n of library as new maven project actionbarsherlock-i18n.

### DIFF
--- a/actionbarsherlock-i18n/AndroidManifest.xml
+++ b/actionbarsherlock-i18n/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="100" android:versionName="4.2.0" package="com.actionbarsherlock.i18n">
+</manifest>

--- a/actionbarsherlock-i18n/abs__strings.json
+++ b/actionbarsherlock-i18n/abs__strings.json
@@ -1,0 +1,22 @@
+{
+    "grab": [
+        "action_bar_home_description", 
+        "action_bar_up_description", 
+        "action_menu_overflow_description", 
+        "action_mode_done", 
+        "activity_chooser_view_see_all", 
+        "activity_chooser_view_dialog_title_default", 
+        "share_action_provider_share_with", 
+        "activitychooserview_choose_application", 
+        "shareactionprovider_share_with", 
+        "shareactionprovider_share_with_application", 
+        "searchview_description_search", 
+        "searchview_description_query", 
+        "searchview_description_clear", 
+        "searchview_description_submit", 
+        "searchview_description_voice"
+    ],
+    "prefix": "abs__",
+    "filename_pattern": "abs__%s.xml",
+    "ignore_default_locale": true
+}

--- a/actionbarsherlock-i18n/pom.xml
+++ b/actionbarsherlock-i18n/pom.xml
@@ -20,6 +20,15 @@
 			<version>${project.version}</version>
 			<type>apklib</type>
 		</dependency>
+		<dependency>
+			<groupId>com.google.android</groupId>
+			<artifactId>android</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.android</groupId>
+			<artifactId>support-v4</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/actionbarsherlock-i18n/pom.xml
+++ b/actionbarsherlock-i18n/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>actionbarsherlock-i18n</artifactId>
+	<name>ActionBarSherlock Internationalization</name>
+	<packaging>apklib</packaging>
+
+	<parent>
+		<groupId>com.actionbarsherlock</groupId>
+		<artifactId>parent</artifactId>
+		<version>4.2.1-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.actionbarsherlock</groupId>
+			<artifactId>actionbarsherlock</artifactId>
+			<version>${project.version}</version>
+			<type>apklib</type>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.jayway.maven.plugins.android.generation2</groupId>
+				<artifactId>android-maven-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.holoeverywhere</groupId>
+					<artifactId>translator</artifactId>
+					<version>1.4.2</version>
+					<extensions>true</extensions>
+					<configuration>
+						<outputDir>${project.basedir}/res</outputDir>
+						<includeDir>${project.basedir}</includeDir>
+						<input>
+							<param>abs__strings.json</param>
+						</input>
+					</configuration>
+					<!-- Uncomment it for rebuild translates in every build -->
+					<!--executions>
+						<execution>
+							<goals>
+								<goal>build</goal>
+							</goals>
+							<phase>initialize</phase>
+						</execution>
+					</executions-->
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+</project>

--- a/actionbarsherlock-i18n/res/values-af/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-af/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Navigeer tuis"</string>
+    <string name="abs__action_bar_up_description">"Navigeer op"</string>
+    <string name="abs__action_menu_overflow_description">"Meer opsies"</string>
+    <string name="abs__action_mode_done">"Klaar"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Kies aktiwiteit"</string>
+    <string name="abs__activity_chooser_view_see_all">"Sien alle"</string>
+    <string name="abs__activitychooserview_choose_application">"Kies \'n program"</string>
+    <string name="abs__searchview_description_clear">"Maak navraag skoon"</string>
+    <string name="abs__searchview_description_query">"Soeknavraag"</string>
+    <string name="abs__searchview_description_search">"Soek"</string>
+    <string name="abs__searchview_description_submit">"Dien navraag in"</string>
+    <string name="abs__searchview_description_voice">"Stemsoektog"</string>
+    <string name="abs__share_action_provider_share_with">"Deel met"</string>
+    <string name="abs__shareactionprovider_share_with">"Deel met"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Deel met %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-am/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-am/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"መነሻ ዳስስ"</string>
+    <string name="abs__action_bar_up_description">"አስስ"</string>
+    <string name="abs__action_menu_overflow_description">"ተጨማሪ አማራጮች"</string>
+    <string name="abs__action_mode_done">"ተከናውኗል"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"እንቅስቃሴ ምረጥ"</string>
+    <string name="abs__activity_chooser_view_see_all">"ሁሉንም ተመልከት"</string>
+    <string name="abs__activitychooserview_choose_application">"መተግበሪያ ምረጥ"</string>
+    <string name="abs__searchview_description_clear">"ጥያቄ አጥራ"</string>
+    <string name="abs__searchview_description_query">"ጥያቄ ፍለጋ"</string>
+    <string name="abs__searchview_description_search">"ፈልግ"</string>
+    <string name="abs__searchview_description_submit">"ጥያቄ አስረክብ"</string>
+    <string name="abs__searchview_description_voice">"የድምፅ ፍለጋ"</string>
+    <string name="abs__share_action_provider_share_with">"ተጋራ ከ"</string>
+    <string name="abs__shareactionprovider_share_with">"ተጋራ ከ"</string>
+    <string name="abs__shareactionprovider_share_with_application">"ከ %s ጋር ተጋራ"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-ar/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-ar/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"التنقل إلى الشاشة الرئيسية"</string>
+    <string name="abs__action_bar_up_description">"التنقل إلى أعلى"</string>
+    <string name="abs__action_menu_overflow_description">"المزيد من الخيارات"</string>
+    <string name="abs__action_mode_done">"تم"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"اختيار نشاط"</string>
+    <string name="abs__activity_chooser_view_see_all">"عرض الكل"</string>
+    <string name="abs__activitychooserview_choose_application">"اختيار تطبيق"</string>
+    <string name="abs__searchview_description_clear">"محو طلب البحث"</string>
+    <string name="abs__searchview_description_query">"طلب البحث"</string>
+    <string name="abs__searchview_description_search">"بحث"</string>
+    <string name="abs__searchview_description_submit">"إرسال طلب البحث"</string>
+    <string name="abs__searchview_description_voice">"البحث الصوتي"</string>
+    <string name="abs__share_action_provider_share_with">"مشاركة مع"</string>
+    <string name="abs__shareactionprovider_share_with">"مشاركة مع"</string>
+    <string name="abs__shareactionprovider_share_with_application">"مشاركة مع %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-be/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-be/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Перайсці да пачатковай старонкі"</string>
+    <string name="abs__action_bar_up_description">"Перайсці ўверх"</string>
+    <string name="abs__action_menu_overflow_description">"Больш налад"</string>
+    <string name="abs__action_mode_done">"Гатова"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Выберыце працэс"</string>
+    <string name="abs__activity_chooser_view_see_all">"Прагледзець усё"</string>
+    <string name="abs__activitychooserview_choose_application">"Выберыце прыкладанне"</string>
+    <string name="abs__searchview_description_clear">"Выдаліць запыт"</string>
+    <string name="abs__searchview_description_query">"Запыт на пошук"</string>
+    <string name="abs__searchview_description_search">"Пошук"</string>
+    <string name="abs__searchview_description_submit">"Адправіць запыт"</string>
+    <string name="abs__searchview_description_voice">"Галасавы пошук"</string>
+    <string name="abs__share_action_provider_share_with">"Апублікаваць з дапамогай"</string>
+    <string name="abs__shareactionprovider_share_with">"Апублікаваць з дапамогай"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Адправiць з дапамогай прыкладання %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-bg/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-bg/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Придвижване към „Начало“"</string>
+    <string name="abs__action_bar_up_description">"Придвижване нагоре"</string>
+    <string name="abs__action_menu_overflow_description">"Още опции"</string>
+    <string name="abs__action_mode_done">"Готово"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Избор на активност"</string>
+    <string name="abs__activity_chooser_view_see_all">"Вижте всички"</string>
+    <string name="abs__activitychooserview_choose_application">"Изберете приложение"</string>
+    <string name="abs__searchview_description_clear">"Изчистване на заявката"</string>
+    <string name="abs__searchview_description_query">"Заявка за търсене"</string>
+    <string name="abs__searchview_description_search">"Търсене"</string>
+    <string name="abs__searchview_description_submit">"Изпращане на заявката"</string>
+    <string name="abs__searchview_description_voice">"Гласово търсене"</string>
+    <string name="abs__share_action_provider_share_with">"Споделяне със:"</string>
+    <string name="abs__shareactionprovider_share_with">"Споделяне със"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Споделяне със: %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-ca/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-ca/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Torna a la pàgina d\'inici"</string>
+    <string name="abs__action_bar_up_description">"Mou cap a dalt"</string>
+    <string name="abs__action_menu_overflow_description">"Més opcions"</string>
+    <string name="abs__action_mode_done">"Fet"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Selecció de l\'activitat"</string>
+    <string name="abs__activity_chooser_view_see_all">"Mostra-les totes"</string>
+    <string name="abs__activitychooserview_choose_application">"Selecciona una aplicació"</string>
+    <string name="abs__searchview_description_clear">"Neteja la consulta"</string>
+    <string name="abs__searchview_description_query">"Consulta de cerca"</string>
+    <string name="abs__searchview_description_search">"Cerca"</string>
+    <string name="abs__searchview_description_submit">"Envia la consulta"</string>
+    <string name="abs__searchview_description_voice">"Cerca per veu"</string>
+    <string name="abs__share_action_provider_share_with">"Comparteix amb"</string>
+    <string name="abs__shareactionprovider_share_with">"Comparteix amb"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Comparteix amb %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-cs/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-cs/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Přejít na plochu"</string>
+    <string name="abs__action_bar_up_description">"Přejít nahoru"</string>
+    <string name="abs__action_menu_overflow_description">"Další možnosti"</string>
+    <string name="abs__action_mode_done">"Hotovo"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Vybrat aktivitu"</string>
+    <string name="abs__activity_chooser_view_see_all">"Zobrazit vše"</string>
+    <string name="abs__activitychooserview_choose_application">"Vybrat aplikaci"</string>
+    <string name="abs__searchview_description_clear">"Smazat dotaz"</string>
+    <string name="abs__searchview_description_query">"Vyhledávací dotaz"</string>
+    <string name="abs__searchview_description_search">"Vyhledávat"</string>
+    <string name="abs__searchview_description_submit">"Odeslat dotaz"</string>
+    <string name="abs__searchview_description_voice">"Hlasové vyhledávání"</string>
+    <string name="abs__share_action_provider_share_with">"Sdílet s"</string>
+    <string name="abs__shareactionprovider_share_with">"Sdílet s"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Sdílet s aplikací %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-da/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-da/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Naviger hjem"</string>
+    <string name="abs__action_bar_up_description">"Naviger op"</string>
+    <string name="abs__action_menu_overflow_description">"Flere valgmuligheder"</string>
+    <string name="abs__action_mode_done">"Udført"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Vælg aktivitet"</string>
+    <string name="abs__activity_chooser_view_see_all">"Se alle"</string>
+    <string name="abs__activitychooserview_choose_application">"Vælg en app"</string>
+    <string name="abs__searchview_description_clear">"Ryd forespørgslen"</string>
+    <string name="abs__searchview_description_query">"Søgeforespørgsel"</string>
+    <string name="abs__searchview_description_search">"Søg"</string>
+    <string name="abs__searchview_description_submit">"Indsend forespørgslen"</string>
+    <string name="abs__searchview_description_voice">"Stemmesøgning"</string>
+    <string name="abs__share_action_provider_share_with">"Del med"</string>
+    <string name="abs__shareactionprovider_share_with">"Del med"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Del med %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-de/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-de/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Zur Startseite navigieren"</string>
+    <string name="abs__action_bar_up_description">"Nach oben navigieren"</string>
+    <string name="abs__action_menu_overflow_description">"Weitere Optionen"</string>
+    <string name="abs__action_mode_done">"Fertig"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Aktivität wählen"</string>
+    <string name="abs__activity_chooser_view_see_all">"Alle anzeigen"</string>
+    <string name="abs__activitychooserview_choose_application">"App auswählen"</string>
+    <string name="abs__searchview_description_clear">"Anfrage löschen"</string>
+    <string name="abs__searchview_description_query">"Suchanfrage"</string>
+    <string name="abs__searchview_description_search">"Suche"</string>
+    <string name="abs__searchview_description_submit">"Anfrage senden"</string>
+    <string name="abs__searchview_description_voice">"Sprachsuche"</string>
+    <string name="abs__share_action_provider_share_with">"Teilen mit"</string>
+    <string name="abs__shareactionprovider_share_with">"Teilen mit"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Mit %s teilen"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-el/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-el/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Πλοήγηση στην αρχική σελίδα"</string>
+    <string name="abs__action_bar_up_description">"Πλοήγηση προς τα επάνω"</string>
+    <string name="abs__action_menu_overflow_description">"Περισσότερες επιλογές"</string>
+    <string name="abs__action_mode_done">"Ολοκληρώθηκε"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Επιλογή δραστηριότητας"</string>
+    <string name="abs__activity_chooser_view_see_all">"Εμφάνιση όλων"</string>
+    <string name="abs__activitychooserview_choose_application">"Επιλέξτε κάποια εφαρμογή"</string>
+    <string name="abs__searchview_description_clear">"Απαλοιφή ερωτήματος"</string>
+    <string name="abs__searchview_description_query">"Ερώτημα αναζήτησης"</string>
+    <string name="abs__searchview_description_search">"Αναζήτηση"</string>
+    <string name="abs__searchview_description_submit">"Υποβολή ερωτήματος"</string>
+    <string name="abs__searchview_description_voice">"Φωνητική αναζήτηση"</string>
+    <string name="abs__share_action_provider_share_with">"Κοινή χρήση με"</string>
+    <string name="abs__shareactionprovider_share_with">"Κοινή χρήση με"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Κοινή χρήση με %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-en-rGB/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-en-rGB/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Navigate home"</string>
+    <string name="abs__action_bar_up_description">"Navigate up"</string>
+    <string name="abs__action_menu_overflow_description">"More options"</string>
+    <string name="abs__action_mode_done">"Done"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Choose activity"</string>
+    <string name="abs__activity_chooser_view_see_all">"See all"</string>
+    <string name="abs__activitychooserview_choose_application">"Choose an app"</string>
+    <string name="abs__searchview_description_clear">"Clear query"</string>
+    <string name="abs__searchview_description_query">"Search query"</string>
+    <string name="abs__searchview_description_search">"Search"</string>
+    <string name="abs__searchview_description_submit">"Submit query"</string>
+    <string name="abs__searchview_description_voice">"Voice search"</string>
+    <string name="abs__share_action_provider_share_with">"Share with"</string>
+    <string name="abs__shareactionprovider_share_with">"Share with"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Share with %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-es-rUS/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-es-rUS/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Desplazarse hasta la página principal"</string>
+    <string name="abs__action_bar_up_description">"Desplazarse hacia arriba"</string>
+    <string name="abs__action_menu_overflow_description">"Más opciones"</string>
+    <string name="abs__action_mode_done">"Listo"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Elige actividad"</string>
+    <string name="abs__activity_chooser_view_see_all">"Ver todas"</string>
+    <string name="abs__activitychooserview_choose_application">"Elige una aplicación."</string>
+    <string name="abs__searchview_description_clear">"Eliminar la consulta"</string>
+    <string name="abs__searchview_description_query">"Consulta de búsqueda"</string>
+    <string name="abs__searchview_description_search">"Buscar"</string>
+    <string name="abs__searchview_description_submit">"Enviar consulta"</string>
+    <string name="abs__searchview_description_voice">"Búsqueda por voz"</string>
+    <string name="abs__share_action_provider_share_with">"Compartir con"</string>
+    <string name="abs__shareactionprovider_share_with">"Compartir con"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Compartir con %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-es/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-es/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Ir al escritorio"</string>
+    <string name="abs__action_bar_up_description">"Desplazarse hacia arriba"</string>
+    <string name="abs__action_menu_overflow_description">"Más opciones"</string>
+    <string name="abs__action_mode_done">"Listo"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Seleccionar actividad"</string>
+    <string name="abs__activity_chooser_view_see_all">"Ver todo"</string>
+    <string name="abs__activitychooserview_choose_application">"Seleccionar una aplicación"</string>
+    <string name="abs__searchview_description_clear">"Borrar consulta"</string>
+    <string name="abs__searchview_description_query">"Consulta"</string>
+    <string name="abs__searchview_description_search">"Buscar"</string>
+    <string name="abs__searchview_description_submit">"Enviar consulta"</string>
+    <string name="abs__searchview_description_voice">"Búsqueda por voz"</string>
+    <string name="abs__share_action_provider_share_with">"Compartir con"</string>
+    <string name="abs__shareactionprovider_share_with">"Compartir con"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Compartir con %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-et/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-et/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Liigu avalehele"</string>
+    <string name="abs__action_bar_up_description">"Liigu üles"</string>
+    <string name="abs__action_menu_overflow_description">"Rohkem valikuid"</string>
+    <string name="abs__action_mode_done">"Valmis"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Tegevuse valimine"</string>
+    <string name="abs__activity_chooser_view_see_all">"Kuva kõik"</string>
+    <string name="abs__activitychooserview_choose_application">"Valige rakendus"</string>
+    <string name="abs__searchview_description_clear">"Tühjenda päring"</string>
+    <string name="abs__searchview_description_query">"Otsingupäring"</string>
+    <string name="abs__searchview_description_search">"Otsing"</string>
+    <string name="abs__searchview_description_submit">"Päringu esitamine"</string>
+    <string name="abs__searchview_description_voice">"Häälotsing"</string>
+    <string name="abs__share_action_provider_share_with">"Jagamine rakendusega:"</string>
+    <string name="abs__shareactionprovider_share_with">"Jaga:"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Jaga rakendusega %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-fa/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-fa/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"رفتن به صفحهٔ اصلی"</string>
+    <string name="abs__action_bar_up_description">"حرکت به بالا"</string>
+    <string name="abs__action_menu_overflow_description">"سایر گزینه‌ها"</string>
+    <string name="abs__action_mode_done">"انجام شد"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"انتخاب فعالیت"</string>
+    <string name="abs__activity_chooser_view_see_all">"مشاهده همه"</string>
+    <string name="abs__activitychooserview_choose_application">"انتخاب برنامه"</string>
+    <string name="abs__searchview_description_clear">"پاک کردن عبارت جستجو"</string>
+    <string name="abs__searchview_description_query">"درخواست جستجو"</string>
+    <string name="abs__searchview_description_search">"جستجو"</string>
+    <string name="abs__searchview_description_submit">"ارسال عبارت جستجو"</string>
+    <string name="abs__searchview_description_voice">"جستجوی صوتی"</string>
+    <string name="abs__share_action_provider_share_with">"اشتراک‌گذاری با"</string>
+    <string name="abs__shareactionprovider_share_with">"اشتراک‌گذاری با"</string>
+    <string name="abs__shareactionprovider_share_with_application">"اشتراک‌گذاری با %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-fi/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-fi/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Siirry etusivulle"</string>
+    <string name="abs__action_bar_up_description">"Siirry ylös"</string>
+    <string name="abs__action_menu_overflow_description">"Lisää asetuksia"</string>
+    <string name="abs__action_mode_done">"Valmis"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Valitse toiminto"</string>
+    <string name="abs__activity_chooser_view_see_all">"Näytä kaikki"</string>
+    <string name="abs__activitychooserview_choose_application">"Valitse sovellus"</string>
+    <string name="abs__searchview_description_clear">"Tyhjennä kysely"</string>
+    <string name="abs__searchview_description_query">"Hakulauseke"</string>
+    <string name="abs__searchview_description_search">"Haku"</string>
+    <string name="abs__searchview_description_submit">"Lähetä kysely"</string>
+    <string name="abs__searchview_description_voice">"Puhehaku"</string>
+    <string name="abs__share_action_provider_share_with">"Jaa seuraavien kanssa"</string>
+    <string name="abs__shareactionprovider_share_with">"Jaa seuraavien kanssa:"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Jaa sovelluksessa %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-fr/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-fr/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Retour à l\'accueil"</string>
+    <string name="abs__action_bar_up_description">"Parcourir vers le haut"</string>
+    <string name="abs__action_menu_overflow_description">"Plus d\'options"</string>
+    <string name="abs__action_mode_done">"OK"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Sélectionnez une activité"</string>
+    <string name="abs__activity_chooser_view_see_all">"Tout afficher"</string>
+    <string name="abs__activitychooserview_choose_application">"Sélectionnez une application"</string>
+    <string name="abs__searchview_description_clear">"Effacer la requête"</string>
+    <string name="abs__searchview_description_query">"Requête de recherche"</string>
+    <string name="abs__searchview_description_search">"Rechercher"</string>
+    <string name="abs__searchview_description_submit">"Envoyer la requête"</string>
+    <string name="abs__searchview_description_voice">"Recherche vocale"</string>
+    <string name="abs__share_action_provider_share_with">"Partager avec"</string>
+    <string name="abs__shareactionprovider_share_with">"Partager avec"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Partager avec %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-hi/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-hi/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"होम पर नेविगेट करें"</string>
+    <string name="abs__action_bar_up_description">"ऊपर नेविगेट करें"</string>
+    <string name="abs__action_menu_overflow_description">"अधिक विकल्प"</string>
+    <string name="abs__action_mode_done">"पूर्ण"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"गतिविधि चुनें"</string>
+    <string name="abs__activity_chooser_view_see_all">"सभी देखें"</string>
+    <string name="abs__activitychooserview_choose_application">"कोई एप्‍लिकेशन चुनें"</string>
+    <string name="abs__searchview_description_clear">"क्‍वेरी साफ़ करें"</string>
+    <string name="abs__searchview_description_query">"खोज क्वेरी"</string>
+    <string name="abs__searchview_description_search">"खोजें"</string>
+    <string name="abs__searchview_description_submit">"क्वेरी सबमिट करें"</string>
+    <string name="abs__searchview_description_voice">"ध्वनि खोज"</string>
+    <string name="abs__share_action_provider_share_with">"इसके साथ साझा करें:"</string>
+    <string name="abs__shareactionprovider_share_with">"इसके साथ साझा करें:"</string>
+    <string name="abs__shareactionprovider_share_with_application">"%s के साथ साझा करें"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-hr/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-hr/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Kreni na početnu"</string>
+    <string name="abs__action_bar_up_description">"Kreni gore"</string>
+    <string name="abs__action_menu_overflow_description">"Više opcija"</string>
+    <string name="abs__action_mode_done">"Gotovo"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Odabir aktivnosti"</string>
+    <string name="abs__activity_chooser_view_see_all">"Prikaži sve"</string>
+    <string name="abs__activitychooserview_choose_application">"Odabir aplikacije"</string>
+    <string name="abs__searchview_description_clear">"Izbriši upit"</string>
+    <string name="abs__searchview_description_query">"Upit za pretraživanje"</string>
+    <string name="abs__searchview_description_search">"Pretraživanje"</string>
+    <string name="abs__searchview_description_submit">"Pošalji upit"</string>
+    <string name="abs__searchview_description_voice">"Glasovno pretraživanje"</string>
+    <string name="abs__share_action_provider_share_with">"Dijeljenje s"</string>
+    <string name="abs__shareactionprovider_share_with">"Dijeljenje sa"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Dijeli s aplikacijom %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-hu/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-hu/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Ugrás a főoldalra"</string>
+    <string name="abs__action_bar_up_description">"Felfele mozgás"</string>
+    <string name="abs__action_menu_overflow_description">"További lehetőségek"</string>
+    <string name="abs__action_mode_done">"Kész"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Tevékenység kiválasztása"</string>
+    <string name="abs__activity_chooser_view_see_all">"Összes megtekintése"</string>
+    <string name="abs__activitychooserview_choose_application">"Válasszon ki egy alkalmazást"</string>
+    <string name="abs__searchview_description_clear">"Lekérdezés törlése"</string>
+    <string name="abs__searchview_description_query">"Keresési lekérdezés"</string>
+    <string name="abs__searchview_description_search">"Keresés"</string>
+    <string name="abs__searchview_description_submit">"Lekérdezés küldése"</string>
+    <string name="abs__searchview_description_voice">"Hangalapú keresés"</string>
+    <string name="abs__share_action_provider_share_with">"Megosztás"</string>
+    <string name="abs__shareactionprovider_share_with">"Megosztás a következővel:"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Ossza meg a következő alkalmazással: %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-in/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-in/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Navigasi ke beranda"</string>
+    <string name="abs__action_bar_up_description">"Navigasi naik"</string>
+    <string name="abs__action_menu_overflow_description">"Opsi lainnya"</string>
+    <string name="abs__action_mode_done">"Selesai"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Pilih kegiatan"</string>
+    <string name="abs__activity_chooser_view_see_all">"Lihat semua"</string>
+    <string name="abs__activitychooserview_choose_application">"Pilih apl"</string>
+    <string name="abs__searchview_description_clear">"Hapus kueri"</string>
+    <string name="abs__searchview_description_query">"Kueri penelusuran"</string>
+    <string name="abs__searchview_description_search">"Penelusuran"</string>
+    <string name="abs__searchview_description_submit">"Mengirimkan kueri"</string>
+    <string name="abs__searchview_description_voice">"Penelusuran suara"</string>
+    <string name="abs__share_action_provider_share_with">"Berbagi dengan"</string>
+    <string name="abs__shareactionprovider_share_with">"Berbagi dengan"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Berbagi dengan %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-it/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-it/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Vai alla home page"</string>
+    <string name="abs__action_bar_up_description">"Vai in alto"</string>
+    <string name="abs__action_menu_overflow_description">"Altre opzioni"</string>
+    <string name="abs__action_mode_done">"Fine"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Scegli attività"</string>
+    <string name="abs__activity_chooser_view_see_all">"Mostra tutto"</string>
+    <string name="abs__activitychooserview_choose_application">"Scegli un\'applicazione"</string>
+    <string name="abs__searchview_description_clear">"Cancella query"</string>
+    <string name="abs__searchview_description_query">"Query di ricerca"</string>
+    <string name="abs__searchview_description_search">"Cerca"</string>
+    <string name="abs__searchview_description_submit">"Invia query"</string>
+    <string name="abs__searchview_description_voice">"Ricerca vocale"</string>
+    <string name="abs__share_action_provider_share_with">"Condividi con"</string>
+    <string name="abs__shareactionprovider_share_with">"Condividi con"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Condividi con %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-iw/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-iw/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"נווט לדף הבית"</string>
+    <string name="abs__action_bar_up_description">"נווט למעלה"</string>
+    <string name="abs__action_menu_overflow_description">"אפשרויות נוספות"</string>
+    <string name="abs__action_mode_done">"סיום"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"בחר פעילות"</string>
+    <string name="abs__activity_chooser_view_see_all">"הצג הכל"</string>
+    <string name="abs__activitychooserview_choose_application">"בחר יישום"</string>
+    <string name="abs__searchview_description_clear">"נקה שאילתה"</string>
+    <string name="abs__searchview_description_query">"שאילתת חיפוש"</string>
+    <string name="abs__searchview_description_search">"חיפוש"</string>
+    <string name="abs__searchview_description_submit">"שלח שאילתה"</string>
+    <string name="abs__searchview_description_voice">"חיפוש קולי"</string>
+    <string name="abs__share_action_provider_share_with">"שתף עם"</string>
+    <string name="abs__shareactionprovider_share_with">"שתף עם"</string>
+    <string name="abs__shareactionprovider_share_with_application">"שתף עם %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-ja/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-ja/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"ホームへ移動"</string>
+    <string name="abs__action_bar_up_description">"上へ移動"</string>
+    <string name="abs__action_menu_overflow_description">"その他のオプション"</string>
+    <string name="abs__action_mode_done">"完了"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"操作の選択"</string>
+    <string name="abs__activity_chooser_view_see_all">"すべて表示"</string>
+    <string name="abs__activitychooserview_choose_application">"アプリの選択"</string>
+    <string name="abs__searchview_description_clear">"検索キーワードを削除"</string>
+    <string name="abs__searchview_description_query">"検索キーワード"</string>
+    <string name="abs__searchview_description_search">"検索"</string>
+    <string name="abs__searchview_description_submit">"検索キーワードを送信"</string>
+    <string name="abs__searchview_description_voice">"音声検索"</string>
+    <string name="abs__share_action_provider_share_with">"共有"</string>
+    <string name="abs__shareactionprovider_share_with">"共有"</string>
+    <string name="abs__shareactionprovider_share_with_application">"%sと共有"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-ko/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-ko/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"홈 탐색"</string>
+    <string name="abs__action_bar_up_description">"위로 탐색"</string>
+    <string name="abs__action_menu_overflow_description">"옵션 더보기"</string>
+    <string name="abs__action_mode_done">"완료"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"작업 선택"</string>
+    <string name="abs__activity_chooser_view_see_all">"전체 보기"</string>
+    <string name="abs__activitychooserview_choose_application">"앱 선택"</string>
+    <string name="abs__searchview_description_clear">"검색어 삭제"</string>
+    <string name="abs__searchview_description_query">"검색어"</string>
+    <string name="abs__searchview_description_search">"검색"</string>
+    <string name="abs__searchview_description_submit">"검색어 보내기"</string>
+    <string name="abs__searchview_description_voice">"음성 검색"</string>
+    <string name="abs__share_action_provider_share_with">"공유 대상"</string>
+    <string name="abs__shareactionprovider_share_with">"공유 대상:"</string>
+    <string name="abs__shareactionprovider_share_with_application">"%s와(과) 공유"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-lt/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-lt/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Naršyti pagrindinį puslapį"</string>
+    <string name="abs__action_bar_up_description">"Naršyti į viršų"</string>
+    <string name="abs__action_menu_overflow_description">"Daugiau parinkčių"</string>
+    <string name="abs__action_mode_done">"Atlikta"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Pasirinkti veiklą"</string>
+    <string name="abs__activity_chooser_view_see_all">"Žr. viską"</string>
+    <string name="abs__activitychooserview_choose_application">"Pasirinkite programą"</string>
+    <string name="abs__searchview_description_clear">"Išvalyti užklausą"</string>
+    <string name="abs__searchview_description_query">"Paieškos užklausa"</string>
+    <string name="abs__searchview_description_search">"Ieškoti"</string>
+    <string name="abs__searchview_description_submit">"Patvirtinti užklausą"</string>
+    <string name="abs__searchview_description_voice">"Paieška balsu"</string>
+    <string name="abs__share_action_provider_share_with">"Bendrinti su"</string>
+    <string name="abs__shareactionprovider_share_with">"Bendrinti su"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Bendrinti su „%s“"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-lv/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-lv/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Pārvietoties uz sākuma ekrānu"</string>
+    <string name="abs__action_bar_up_description">"Pārvietoties augšup"</string>
+    <string name="abs__action_menu_overflow_description">"Vairāk opciju"</string>
+    <string name="abs__action_mode_done">"Gatavs"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Darbības izvēle"</string>
+    <string name="abs__activity_chooser_view_see_all">"Skatīt visu"</string>
+    <string name="abs__activitychooserview_choose_application">"Izvēlieties lietotni"</string>
+    <string name="abs__searchview_description_clear">"Notīrīt vaicājumu"</string>
+    <string name="abs__searchview_description_query">"Meklēšanas vaicājums"</string>
+    <string name="abs__searchview_description_search">"Meklēt"</string>
+    <string name="abs__searchview_description_submit">"Iesniedziet vaicājumu."</string>
+    <string name="abs__searchview_description_voice">"Meklēšana ar balsi"</string>
+    <string name="abs__share_action_provider_share_with">"Kopīgošana ar:"</string>
+    <string name="abs__shareactionprovider_share_with">"Kopīgot ar:"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Kopīgot ar lietojumprogrammu %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-ms/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-ms/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Navigasi laman utama"</string>
+    <string name="abs__action_bar_up_description">"Navigasi ke atas"</string>
+    <string name="abs__action_menu_overflow_description">"Lagi pilihan"</string>
+    <string name="abs__action_mode_done">"Selesai"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Pilih aktiviti"</string>
+    <string name="abs__activity_chooser_view_see_all">"Lihat semua"</string>
+    <string name="abs__activitychooserview_choose_application">"Pilih apl"</string>
+    <string name="abs__searchview_description_clear">"Pertanyaan jelas"</string>
+    <string name="abs__searchview_description_query">"Pertanyaan carian"</string>
+    <string name="abs__searchview_description_search">"Carian"</string>
+    <string name="abs__searchview_description_submit">"Serah pertanyaan"</string>
+    <string name="abs__searchview_description_voice">"Carian suara"</string>
+    <string name="abs__share_action_provider_share_with">"Kongsi dengan"</string>
+    <string name="abs__shareactionprovider_share_with">"Kongsi dengan"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Kongsi dengan %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-nb/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-nb/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Gå til startsiden"</string>
+    <string name="abs__action_bar_up_description">"Gå opp"</string>
+    <string name="abs__action_menu_overflow_description">"Flere alternativer"</string>
+    <string name="abs__action_mode_done">"Ferdig"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Velg aktivitet"</string>
+    <string name="abs__activity_chooser_view_see_all">"Se alle"</string>
+    <string name="abs__activitychooserview_choose_application">"Velg en app"</string>
+    <string name="abs__searchview_description_clear">"Slett søket"</string>
+    <string name="abs__searchview_description_query">"Søkeord"</string>
+    <string name="abs__searchview_description_search">"Søk"</string>
+    <string name="abs__searchview_description_submit">"Send inn spørsmål"</string>
+    <string name="abs__searchview_description_voice">"Talesøk"</string>
+    <string name="abs__share_action_provider_share_with">"Deling med"</string>
+    <string name="abs__shareactionprovider_share_with">"Del med"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Del med %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-nl/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-nl/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Navigeren naar startpositie"</string>
+    <string name="abs__action_bar_up_description">"Omhoog navigeren"</string>
+    <string name="abs__action_menu_overflow_description">"Meer opties"</string>
+    <string name="abs__action_mode_done">"Gereed"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Een activiteit kiezen"</string>
+    <string name="abs__activity_chooser_view_see_all">"Alles weergeven"</string>
+    <string name="abs__activitychooserview_choose_application">"Een app selecteren"</string>
+    <string name="abs__searchview_description_clear">"Zoekopdracht wissen"</string>
+    <string name="abs__searchview_description_query">"Zoekopdracht"</string>
+    <string name="abs__searchview_description_search">"Zoeken"</string>
+    <string name="abs__searchview_description_submit">"Zoekopdracht verzenden"</string>
+    <string name="abs__searchview_description_voice">"Spraakgestuurd zoeken"</string>
+    <string name="abs__share_action_provider_share_with">"Delen met"</string>
+    <string name="abs__shareactionprovider_share_with">"Delen met"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Delen met %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-pl/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-pl/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Przejdź do strony głównej"</string>
+    <string name="abs__action_bar_up_description">"Przejdź wyżej"</string>
+    <string name="abs__action_menu_overflow_description">"Więcej opcji"</string>
+    <string name="abs__action_mode_done">"Gotowe"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Wybierz działanie"</string>
+    <string name="abs__activity_chooser_view_see_all">"Zobacz wszystkie"</string>
+    <string name="abs__activitychooserview_choose_application">"Wybierz aplikację"</string>
+    <string name="abs__searchview_description_clear">"Wyczyść zapytanie"</string>
+    <string name="abs__searchview_description_query">"Wyszukiwane hasło"</string>
+    <string name="abs__searchview_description_search">"Szukaj"</string>
+    <string name="abs__searchview_description_submit">"Wyślij zapytanie"</string>
+    <string name="abs__searchview_description_voice">"Wyszukiwanie głosowe"</string>
+    <string name="abs__share_action_provider_share_with">"Udostępnij przez"</string>
+    <string name="abs__shareactionprovider_share_with">"Udostępnij przez"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Udostępnij przez %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-pt-rPT/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-pt-rPT/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Navegar para página inicial"</string>
+    <string name="abs__action_bar_up_description">"Navegar para cima"</string>
+    <string name="abs__action_menu_overflow_description">"Mais opções"</string>
+    <string name="abs__action_mode_done">"Concluído"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Escolher atividade"</string>
+    <string name="abs__activity_chooser_view_see_all">"Ver tudo"</string>
+    <string name="abs__activitychooserview_choose_application">"Escolher uma aplicação"</string>
+    <string name="abs__searchview_description_clear">"Limpar consulta"</string>
+    <string name="abs__searchview_description_query">"Consulta de pesquisa"</string>
+    <string name="abs__searchview_description_search">"Pesquisar"</string>
+    <string name="abs__searchview_description_submit">"Enviar consulta"</string>
+    <string name="abs__searchview_description_voice">"Pesquisa por voz"</string>
+    <string name="abs__share_action_provider_share_with">"Partilhar com"</string>
+    <string name="abs__shareactionprovider_share_with">"Partilhar com:"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Compartilhar com %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-pt/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-pt/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Navegar na página inicial"</string>
+    <string name="abs__action_bar_up_description">"Navegar para cima"</string>
+    <string name="abs__action_menu_overflow_description">"Mais opções"</string>
+    <string name="abs__action_mode_done">"Concluído"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Selecione a atividade"</string>
+    <string name="abs__activity_chooser_view_see_all">"Ver tudo"</string>
+    <string name="abs__activitychooserview_choose_application">"Selecione um aplicativo"</string>
+    <string name="abs__searchview_description_clear">"Limpar consulta"</string>
+    <string name="abs__searchview_description_query">"Consulta de pesquisa"</string>
+    <string name="abs__searchview_description_search">"Pesquisar"</string>
+    <string name="abs__searchview_description_submit">"Enviar consulta"</string>
+    <string name="abs__searchview_description_voice">"Pesquisa por voz"</string>
+    <string name="abs__share_action_provider_share_with">"Compartilhar com"</string>
+    <string name="abs__shareactionprovider_share_with">"Compartilhar com"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Compartilhar com %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-ro/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-ro/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Navigaţi la ecranul de pornire"</string>
+    <string name="abs__action_bar_up_description">"Navigaţi în sus"</string>
+    <string name="abs__action_menu_overflow_description">"Mai multe opţiuni"</string>
+    <string name="abs__action_mode_done">"Terminat"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Alegeţi activitatea"</string>
+    <string name="abs__activity_chooser_view_see_all">"Afişaţi-le pe toate"</string>
+    <string name="abs__activitychooserview_choose_application">"Alegeţi o aplicaţie"</string>
+    <string name="abs__searchview_description_clear">"Ştergeţi interogarea"</string>
+    <string name="abs__searchview_description_query">"Interogare de căutare"</string>
+    <string name="abs__searchview_description_search">"Căutaţi"</string>
+    <string name="abs__searchview_description_submit">"Trimiteţi interogarea"</string>
+    <string name="abs__searchview_description_voice">"Căutare vocală"</string>
+    <string name="abs__share_action_provider_share_with">"Distribuiţi pentru"</string>
+    <string name="abs__shareactionprovider_share_with">"Permiteţi accesul pentru"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Permiteţi accesul pentru %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-ru/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-ru/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Перейти на главную"</string>
+    <string name="abs__action_bar_up_description">"Перейти вверх"</string>
+    <string name="abs__action_menu_overflow_description">"Ещё"</string>
+    <string name="abs__action_mode_done">"Готово"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Выберите"</string>
+    <string name="abs__activity_chooser_view_see_all">"Просмотреть все"</string>
+    <string name="abs__activitychooserview_choose_application">"Выберите приложение"</string>
+    <string name="abs__searchview_description_clear">"Удалить запрос"</string>
+    <string name="abs__searchview_description_query">"Поисковый запрос"</string>
+    <string name="abs__searchview_description_search">"Поиск"</string>
+    <string name="abs__searchview_description_submit">"Отправить запрос"</string>
+    <string name="abs__searchview_description_voice">"Голосовой поиск"</string>
+    <string name="abs__share_action_provider_share_with">"Открыть доступ"</string>
+    <string name="abs__shareactionprovider_share_with">"Открыть доступ:"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Открыть доступ приложению \"%s\""</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-sk/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-sk/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Prejsť na plochu"</string>
+    <string name="abs__action_bar_up_description">"Prejsť na"</string>
+    <string name="abs__action_menu_overflow_description">"Viac možností"</string>
+    <string name="abs__action_mode_done">"Hotovo"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Vybrať aktivitu"</string>
+    <string name="abs__activity_chooser_view_see_all">"Zobraziť všetky"</string>
+    <string name="abs__activitychooserview_choose_application">"Zvoľte aplikáciu"</string>
+    <string name="abs__searchview_description_clear">"Jasný dopyt"</string>
+    <string name="abs__searchview_description_query">"Vyhľadávací dopyt"</string>
+    <string name="abs__searchview_description_search">"Hľadať"</string>
+    <string name="abs__searchview_description_submit">"Odoslať dopyt"</string>
+    <string name="abs__searchview_description_voice">"Hlasové vyhľadávanie"</string>
+    <string name="abs__share_action_provider_share_with">"Zdieľať s"</string>
+    <string name="abs__shareactionprovider_share_with">"Zdieľať s"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Zdieľať s aplikáciou %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-sl/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-sl/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Krmarjenje domov"</string>
+    <string name="abs__action_bar_up_description">"Krmarjenje navzgor"</string>
+    <string name="abs__action_menu_overflow_description">"Več možnosti"</string>
+    <string name="abs__action_mode_done">"Končano"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Izberite dejavnost"</string>
+    <string name="abs__activity_chooser_view_see_all">"Pokaži vse"</string>
+    <string name="abs__activitychooserview_choose_application">"Izberite program"</string>
+    <string name="abs__searchview_description_clear">"Izbris poizvedbe"</string>
+    <string name="abs__searchview_description_query">"Iskalna poizvedba"</string>
+    <string name="abs__searchview_description_search">"Iskanje"</string>
+    <string name="abs__searchview_description_submit">"Pošlji poizvedbo"</string>
+    <string name="abs__searchview_description_voice">"Glasovno iskanje"</string>
+    <string name="abs__share_action_provider_share_with">"Delite z"</string>
+    <string name="abs__shareactionprovider_share_with">"Delite z"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Delite s programom %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-sr/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-sr/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Кретање до Почетне"</string>
+    <string name="abs__action_bar_up_description">"Кретање нагоре"</string>
+    <string name="abs__action_menu_overflow_description">"Још опција"</string>
+    <string name="abs__action_mode_done">"Готово"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Избор активности"</string>
+    <string name="abs__activity_chooser_view_see_all">"Прикажи све"</string>
+    <string name="abs__activitychooserview_choose_application">"Изаберите апликацију"</string>
+    <string name="abs__searchview_description_clear">"Обриши упит"</string>
+    <string name="abs__searchview_description_query">"Упит за претрагу"</string>
+    <string name="abs__searchview_description_search">"Претражи"</string>
+    <string name="abs__searchview_description_submit">"Пошаљи упит"</string>
+    <string name="abs__searchview_description_voice">"Гласовна претрага"</string>
+    <string name="abs__share_action_provider_share_with">"Дели са"</string>
+    <string name="abs__shareactionprovider_share_with">"Дели са"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Дели са апликацијом %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-sv/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-sv/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Visa startsidan"</string>
+    <string name="abs__action_bar_up_description">"Navigera uppåt"</string>
+    <string name="abs__action_menu_overflow_description">"Fler alternativ"</string>
+    <string name="abs__action_mode_done">"Klar"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Välj aktivitet"</string>
+    <string name="abs__activity_chooser_view_see_all">"Visa alla"</string>
+    <string name="abs__activitychooserview_choose_application">"Välj en app"</string>
+    <string name="abs__searchview_description_clear">"Ta bort frågan"</string>
+    <string name="abs__searchview_description_query">"Sökfråga"</string>
+    <string name="abs__searchview_description_search">"Sök"</string>
+    <string name="abs__searchview_description_submit">"Skicka fråga"</string>
+    <string name="abs__searchview_description_voice">"Röstsökning"</string>
+    <string name="abs__share_action_provider_share_with">"Dela med"</string>
+    <string name="abs__shareactionprovider_share_with">"Dela med"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Dela med %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-sw/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-sw/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Abiri nyumbani"</string>
+    <string name="abs__action_bar_up_description">"Ongoza"</string>
+    <string name="abs__action_menu_overflow_description">"Chaguo zaidi"</string>
+    <string name="abs__action_mode_done">"Kwisha"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Chagua shughuli"</string>
+    <string name="abs__activity_chooser_view_see_all">"Angalia zote"</string>
+    <string name="abs__activitychooserview_choose_application">"Chagua programu"</string>
+    <string name="abs__searchview_description_clear">"Futa swali"</string>
+    <string name="abs__searchview_description_query">"Hoja ya utafutaji"</string>
+    <string name="abs__searchview_description_search">"Tafuta"</string>
+    <string name="abs__searchview_description_submit">"Wasilisha hoja"</string>
+    <string name="abs__searchview_description_voice">"Utafutaji wa sauti"</string>
+    <string name="abs__share_action_provider_share_with">"Shiriki na"</string>
+    <string name="abs__shareactionprovider_share_with">"Gawa na"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Gawa na %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-th/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-th/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"นำทางไปหน้าแรก"</string>
+    <string name="abs__action_bar_up_description">"นำทางขึ้น"</string>
+    <string name="abs__action_menu_overflow_description">"ตัวเลือกเพิ่มเติม"</string>
+    <string name="abs__action_mode_done">"เสร็จสิ้น"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"เลือกกิจกรรม"</string>
+    <string name="abs__activity_chooser_view_see_all">"ดูทั้งหมด"</string>
+    <string name="abs__activitychooserview_choose_application">"เลือกแอปพลิเคชัน"</string>
+    <string name="abs__searchview_description_clear">"ล้างข้อความค้นหา"</string>
+    <string name="abs__searchview_description_query">"คำค้นหา"</string>
+    <string name="abs__searchview_description_search">"ค้นหา"</string>
+    <string name="abs__searchview_description_submit">"ส่งข้อความค้นหา"</string>
+    <string name="abs__searchview_description_voice">"ค้นหาด้วยเสียง"</string>
+    <string name="abs__share_action_provider_share_with">"แบ่งปันกับ"</string>
+    <string name="abs__shareactionprovider_share_with">"แบ่งปันกับ"</string>
+    <string name="abs__shareactionprovider_share_with_application">"แบ่งปันด้วย %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-tl/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-tl/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Magnabiga sa home"</string>
+    <string name="abs__action_bar_up_description">"Magnabiga pataas"</string>
+    <string name="abs__action_menu_overflow_description">"Higit pang mga pagpipilian"</string>
+    <string name="abs__action_mode_done">"Tapos na"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Pumili ng aktibidad"</string>
+    <string name="abs__activity_chooser_view_see_all">"Tingnan lahat"</string>
+    <string name="abs__activitychooserview_choose_application">"Pumili ng isang app"</string>
+    <string name="abs__searchview_description_clear">"I-clear ang query"</string>
+    <string name="abs__searchview_description_query">"Query sa paghahanap"</string>
+    <string name="abs__searchview_description_search">"Paghahanap"</string>
+    <string name="abs__searchview_description_submit">"Isumite ang query"</string>
+    <string name="abs__searchview_description_voice">"Paghahanap gamit ang boses"</string>
+    <string name="abs__share_action_provider_share_with">"Ibahagi sa"</string>
+    <string name="abs__shareactionprovider_share_with">"Ibahagi sa"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Ibahagi sa %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-tr/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-tr/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Ana sayfaya git"</string>
+    <string name="abs__action_bar_up_description">"Yukarı git"</string>
+    <string name="abs__action_menu_overflow_description">"Diğer seçenekler"</string>
+    <string name="abs__action_mode_done">"Bitti"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Etkinlik seçin"</string>
+    <string name="abs__activity_chooser_view_see_all">"Tümünü göster"</string>
+    <string name="abs__activitychooserview_choose_application">"Bir uygulama seçin"</string>
+    <string name="abs__searchview_description_clear">"Sorguyu temizle"</string>
+    <string name="abs__searchview_description_query">"Arama sorgusu"</string>
+    <string name="abs__searchview_description_search">"Ara"</string>
+    <string name="abs__searchview_description_submit">"Sorguyu gönder"</string>
+    <string name="abs__searchview_description_voice">"Sesli arama"</string>
+    <string name="abs__share_action_provider_share_with">"Şununla paylaş:"</string>
+    <string name="abs__shareactionprovider_share_with">"Şununla paylaş:"</string>
+    <string name="abs__shareactionprovider_share_with_application">"%s ile paylaş"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-uk/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-uk/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Перейти на головну"</string>
+    <string name="abs__action_bar_up_description">"Перейти вгору"</string>
+    <string name="abs__action_menu_overflow_description">"Інші варіанти"</string>
+    <string name="abs__action_mode_done">"Готово"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Вибрати дію"</string>
+    <string name="abs__activity_chooser_view_see_all">"Переглянути всі"</string>
+    <string name="abs__activitychooserview_choose_application">"Вибрати програму"</string>
+    <string name="abs__searchview_description_clear">"Очистити запит"</string>
+    <string name="abs__searchview_description_query">"Пошуковий запит"</string>
+    <string name="abs__searchview_description_search">"Пошук"</string>
+    <string name="abs__searchview_description_submit">"Наіслати запит"</string>
+    <string name="abs__searchview_description_voice">"Голосовий пошук"</string>
+    <string name="abs__share_action_provider_share_with">"Спільний доступ для:"</string>
+    <string name="abs__shareactionprovider_share_with">"Надіслати через"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Надіслати через %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-vi/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-vi/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Điều hướng về trang chủ"</string>
+    <string name="abs__action_bar_up_description">"Điều hướng lên trên"</string>
+    <string name="abs__action_menu_overflow_description">"Tùy chọn khác"</string>
+    <string name="abs__action_mode_done">"Xong"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Chọn hoạt động"</string>
+    <string name="abs__activity_chooser_view_see_all">"Xem tất cả"</string>
+    <string name="abs__activitychooserview_choose_application">"Chọn một ứng dụng"</string>
+    <string name="abs__searchview_description_clear">"Xóa truy vấn"</string>
+    <string name="abs__searchview_description_query">"Truy vấn tìm kiếm"</string>
+    <string name="abs__searchview_description_search">"Tìm kiếm"</string>
+    <string name="abs__searchview_description_submit">"Gửi truy vấn"</string>
+    <string name="abs__searchview_description_voice">"Tìm kiếm bằng giọng nói"</string>
+    <string name="abs__share_action_provider_share_with">"Chia sẻ với"</string>
+    <string name="abs__shareactionprovider_share_with">"Chia sẻ với"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Chia sẻ với %s"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-zh-rCN/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-zh-rCN/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"导航首页"</string>
+    <string name="abs__action_bar_up_description">"向上导航"</string>
+    <string name="abs__action_menu_overflow_description">"更多选项"</string>
+    <string name="abs__action_mode_done">"完成"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"选择活动"</string>
+    <string name="abs__activity_chooser_view_see_all">"查看全部"</string>
+    <string name="abs__activitychooserview_choose_application">"选择应用"</string>
+    <string name="abs__searchview_description_clear">"清除查询"</string>
+    <string name="abs__searchview_description_query">"搜索查询"</string>
+    <string name="abs__searchview_description_search">"搜索"</string>
+    <string name="abs__searchview_description_submit">"提交查询"</string>
+    <string name="abs__searchview_description_voice">"语音搜索"</string>
+    <string name="abs__share_action_provider_share_with">"分享对象"</string>
+    <string name="abs__shareactionprovider_share_with">"共享对象"</string>
+    <string name="abs__shareactionprovider_share_with_application">"与“%s”共享"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-zh-rTW/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-zh-rTW/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"瀏覽首頁"</string>
+    <string name="abs__action_bar_up_description">"向上瀏覽"</string>
+    <string name="abs__action_menu_overflow_description">"更多選項"</string>
+    <string name="abs__action_mode_done">"完成"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"選擇活動"</string>
+    <string name="abs__activity_chooser_view_see_all">"全部顯示"</string>
+    <string name="abs__activitychooserview_choose_application">"選擇應用程式"</string>
+    <string name="abs__searchview_description_clear">"清除查詢"</string>
+    <string name="abs__searchview_description_query">"搜尋查詢"</string>
+    <string name="abs__searchview_description_search">"搜尋"</string>
+    <string name="abs__searchview_description_submit">"提交查詢"</string>
+    <string name="abs__searchview_description_voice">"語音搜尋"</string>
+    <string name="abs__share_action_provider_share_with">"分享活動"</string>
+    <string name="abs__shareactionprovider_share_with">"分享對象："</string>
+    <string name="abs__shareactionprovider_share_with_application">"與「%s」分享"</string>
+</resources>

--- a/actionbarsherlock-i18n/res/values-zu/abs__strings.xml
+++ b/actionbarsherlock-i18n/res/values-zu/abs__strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><resources>
+    <string name="abs__action_bar_home_description">"Zulazulela ekhaya"</string>
+    <string name="abs__action_bar_up_description">"Zulazulela phezulu"</string>
+    <string name="abs__action_menu_overflow_description">"Izinketho ezingaphezulu"</string>
+    <string name="abs__action_mode_done">"Kwenziwe"</string>
+    <string name="abs__activity_chooser_view_dialog_title_default">"Khetha okwenziwayo"</string>
+    <string name="abs__activity_chooser_view_see_all">"Buka konke"</string>
+    <string name="abs__activitychooserview_choose_application">"Khetha insiza"</string>
+    <string name="abs__searchview_description_clear">"xazulula umbuzo"</string>
+    <string name="abs__searchview_description_query">"Umbuzo wosesho"</string>
+    <string name="abs__searchview_description_search">"Sesha"</string>
+    <string name="abs__searchview_description_submit">"Thumela umbuzo"</string>
+    <string name="abs__searchview_description_voice">"Ukusesha ngezwi"</string>
+    <string name="abs__share_action_provider_share_with">"Yabelana no"</string>
+    <string name="abs__shareactionprovider_share_with">"Yabelana no"</string>
+    <string name="abs__shareactionprovider_share_with_application">"Yabelana no %s"</string>
+</resources>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 	<modules>
 		<module>actionbarsherlock</module>
 		<module>actionbarsherlock-samples</module>
+		<module>actionbarsherlock-i18n</module>
 	</modules>
 
 	<scm>


### PR DESCRIPTION
Manual rebuild of translates:
cd library-i18n
mvn translator:build

Auto rebuild:
Uncomment block in library-i18n/pom.xml and move it in <plugins> block;

Used HoloEverywhere Translator 1.4.2, but it not yet release. You need manual install 1.4.2 version into local repository.
