### PR TITLE
Fixes homeAsUp not enabling the home action item. Closes #746.

### DIFF
--- a/actionbarsherlock/src/com/actionbarsherlock/internal/app/ActionBarImpl.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/internal/app/ActionBarImpl.java
@@ -170,7 +170,12 @@ public class ActionBarImpl extends ActionBar {
 
         // Older apps get the home button interaction enabled by default.
         // Newer apps need to enable it explicitly.
-        setHomeButtonEnabled(mContext.getApplicationInfo().targetSdkVersion < 14);
+        boolean homeButtonEnabled = mContext.getApplicationInfo().targetSdkVersion < Build.VERSION_CODES.ICE_CREAM_SANDWICH;
+
+        // If the homeAsUp display option is set, always enable the home button.
+        homeButtonEnabled |= (mActionView.getDisplayOptions() & ActionBar.DISPLAY_HOME_AS_UP) != 0;
+
+        setHomeButtonEnabled(homeButtonEnabled);
 
         setHasEmbeddedTabs(getResources_getBoolean(mContext,
                 R.bool.abs__action_bar_embed_tabs));

--- a/actionbarsherlock/src/com/actionbarsherlock/internal/app/ActionBarWrapper.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/internal/app/ActionBarWrapper.java
@@ -26,6 +26,10 @@ public class ActionBarWrapper extends ActionBar implements android.app.ActionBar
         mActionBar = activity.getActionBar();
         if (mActionBar != null) {
             mActionBar.addOnMenuVisibilityListener(this);
+
+            // Fixes issue #746
+            int displayOptions = mActionBar.getDisplayOptions();
+            mActionBar.setHomeButtonEnabled((displayOptions & DISPLAY_HOME_AS_UP) != 0);
         }
     }
 
@@ -132,11 +136,19 @@ public class ActionBarWrapper extends ActionBar implements android.app.ActionBar
     @Override
     public void setDisplayOptions(int options) {
         mActionBar.setDisplayOptions(options);
+
+        // Fixes issue #746
+        mActionBar.setHomeButtonEnabled((options & DISPLAY_HOME_AS_UP) != 0);
     }
 
     @Override
     public void setDisplayOptions(int options, int mask) {
         mActionBar.setDisplayOptions(options, mask);
+
+        // Fixes issue #746
+        if ((mask & DISPLAY_HOME_AS_UP) != 0) {
+            mActionBar.setHomeButtonEnabled((options & DISPLAY_HOME_AS_UP) != 0);
+        }
     }
 
     @Override


### PR DESCRIPTION
When setting homeAsUp in the theme's display options on pre-16 devices,
the home action item was not being enabled. Fix this by reading the
attribute and manually calling the setHomeButtonEnabled API.
