### PR TITLE
Fix for crash during monkey testing.

### DIFF
--- a/library/src/com/actionbarsherlock/internal/ActionBarSherlockNative.java
+++ b/library/src/com/actionbarsherlock/internal/ActionBarSherlockNative.java
@@ -75,7 +75,7 @@ public class ActionBarSherlockNative extends ActionBarSherlock {
     public boolean dispatchOptionsItemSelected(android.view.MenuItem item) {
         if (DEBUG) Log.d(TAG, "[dispatchOptionsItemSelected] item: " + item.getTitleCondensed());
 
-        final boolean result = callbackOptionsItemSelected(mMenu.findItem(item));
+        final boolean result = mMenu!=null && callbackOptionsItemSelected(mMenu.findItem(item));
         if (DEBUG) Log.d(TAG, "[dispatchOptionsItemSelected] returning " + result);
         return result;
     }


### PR DESCRIPTION
adb -e shell monkey -p my.package -v 10000

java.lang.NullPointerException
at com.actionbarsherlock.internal.ActionBarSherlockNative.dispatchOptionsItemSelected(ActionBarSherlockNative.java:78)
at com.actionbarsherlock.app.SherlockPreferenceActivity.onOptionsItemSelected(SherlockPreferenceActivity.java:148)
at android.app.Activity.onMenuItemSelected(Activity.java:2534)
at com.android.internal.widget.ActionBarView$3.onClick(ActionBarView.java:167)
