### PR TITLE
Fix crash when use IcsSpinner as actionView in ActionBar

### DIFF
--- a/actionbarsherlock/src/com/actionbarsherlock/internal/widget/IcsSpinner.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/internal/widget/IcsSpinner.java
@@ -77,6 +77,10 @@ public class IcsSpinner extends IcsAbsSpinner implements OnClickListener {
     private boolean mDisableChildrenWhenDisabled;
 
     private Rect mTempRect = new Rect();
+    
+    public IcsSpinner(Context context) {
+    	this(context, null);
+	}
 
     public IcsSpinner(Context context, AttributeSet attrs) {
         this(context, attrs, R.attr.actionDropDownStyle);


### PR DESCRIPTION
MenuInflater throw constructor can not be found exception when IcsSpinner use as android:actionView of a menu item
