### PR TITLE
SearchView keeps a query on expanded action

### DIFF
--- a/library/src/com/actionbarsherlock/widget/SearchView.java
+++ b/library/src/com/actionbarsherlock/widget/SearchView.java
@@ -1286,7 +1286,6 @@ public class SearchView extends LinearLayout implements CollapsibleActionView {
         mExpandedInActionView = true;
         mCollapsedImeOptions = mQueryTextView.getImeOptions();
         mQueryTextView.setImeOptions(mCollapsedImeOptions | EditorInfo.IME_FLAG_NO_FULLSCREEN);
-        mQueryTextView.setText("");
         setIconified(false);
     }
 


### PR DESCRIPTION
While working on a project I faced the problem that search term was not saved for SearchView. THen I found in the code, that the text view is automatically cleaned up in onActionExpanded callback. PLease review the change
