### PR TITLE
Add support for different icon in legacy menu

### DIFF
--- a/actionbarsherlock/res/values/abs__attrs.xml
+++ b/actionbarsherlock/res/values/abs__attrs.xml
@@ -341,6 +341,8 @@
              the title should be sufficient in describing this item. -->
         <attr name="android:icon" />
 
+        <attr name="legacyIcon" format="reference|integer" />
+
         <!-- The alphabetic shortcut key.  This is the shortcut when using a keyboard
              with alphabetic keys. -->
         <attr name="android:alphabeticShortcut" />

--- a/actionbarsherlock/src/com/actionbarsherlock/internal/view/menu/ActionMenuItem.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/internal/view/menu/ActionMenuItem.java
@@ -275,4 +275,21 @@ public class ActionMenuItem implements MenuItem {
         // No need to save the listener; ActionMenuItem does not support collapsing items.
         return this;
     }
+
+    @Override
+    public MenuItem setLegacyIcon(Drawable icon) {
+        // Do nothing
+        return this;
+    }
+
+    @Override
+    public MenuItem setLegacyIcon(int iconRes) {
+        // Do nothing
+        return this;
+    }
+
+    @Override
+    public Drawable getLegacyIcon() {
+        return null;
+    }
 }

--- a/actionbarsherlock/src/com/actionbarsherlock/internal/view/menu/MenuBuilder.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/internal/view/menu/MenuBuilder.java
@@ -1320,7 +1320,13 @@ public class MenuBuilder implements Menu {
                 nativeItem = menu.add(nonActionItem.getGroupId(), nonActionItem.getItemId(),
                         nonActionItem.getOrder(), nonActionItem.getTitle());
             }
-            nativeItem.setIcon(nonActionItem.getIcon());
+
+            if (nonActionItem.getLegacyIcon() != null) {
+                nativeItem.setIcon(nonActionItem.getLegacyIcon());
+            } else {
+                nativeItem.setIcon(nonActionItem.getIcon());
+            }
+
             nativeItem.setOnMenuItemClickListener(listener);
             nativeItem.setEnabled(nonActionItem.isEnabled());
             nativeItem.setIntent(nonActionItem.getIntent());

--- a/actionbarsherlock/src/com/actionbarsherlock/internal/view/menu/MenuItemImpl.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/internal/view/menu/MenuItemImpl.java
@@ -60,6 +60,9 @@ public final class MenuItemImpl implements MenuItem {
      */
     private int mIconResId = NO_ICON;
 
+    private Drawable mLegacyIconDrawable;
+    private int mLegacyIconResId = NO_ICON;
+
     /** The menu to which this item belongs */
     private MenuBuilder mMenu;
     /** If this item should launch a sub menu, this is the sub menu to launch */
@@ -398,6 +401,36 @@ public final class MenuItemImpl implements MenuItem {
     public MenuItem setIcon(int iconResId) {
         mIconDrawable = null;
         mIconResId = iconResId;
+
+        // If we have a view, we need to push the Drawable to them
+        mMenu.onItemsChanged(false);
+
+        return this;
+    }
+
+    public Drawable getLegacyIcon() {
+        if (mLegacyIconDrawable != null) {
+            return mLegacyIconDrawable;
+        }
+
+        if (mLegacyIconResId != NO_ICON) {
+            return mMenu.getResources().getDrawable(mLegacyIconResId);
+        }
+
+        return null;
+    }
+
+    public MenuItem setLegacyIcon(Drawable icon) {
+        mLegacyIconResId = NO_ICON;
+        mLegacyIconDrawable = icon;
+        mMenu.onItemsChanged(false);
+
+        return this;
+    }
+
+    public MenuItem setLegacyIcon(int iconResId) {
+        mLegacyIconDrawable = null;
+        mLegacyIconResId = iconResId;
 
         // If we have a view, we need to push the Drawable to them
         mMenu.onItemsChanged(false);

--- a/actionbarsherlock/src/com/actionbarsherlock/internal/view/menu/MenuItemWrapper.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/internal/view/menu/MenuItemWrapper.java
@@ -307,4 +307,21 @@ public class MenuItemWrapper implements MenuItem, android.view.MenuItem.OnMenuIt
 
         return this;
     }
+
+    @Override
+    public MenuItem setLegacyIcon(Drawable icon) {
+        // Do nothing
+        return this;
+    }
+
+    @Override
+    public MenuItem setLegacyIcon(int iconRes) {
+        // Do nothing
+        return this;
+    }
+
+    @Override
+    public Drawable getLegacyIcon() {
+        return null;
+    }
 }

--- a/actionbarsherlock/src/com/actionbarsherlock/view/MenuInflater.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/view/MenuInflater.java
@@ -264,6 +264,7 @@ public class MenuInflater {
         private CharSequence itemTitle;
         private CharSequence itemTitleCondensed;
         private int itemIconResId;
+        private int itemLegacyIconResId;
         private char itemAlphabeticShortcut;
         private char itemNumericShortcut;
         /**
@@ -350,6 +351,7 @@ public class MenuInflater {
             itemTitle = a.getText(R.styleable.SherlockMenuItem_android_title);
             itemTitleCondensed = a.getText(R.styleable.SherlockMenuItem_android_titleCondensed);
             itemIconResId = a.getResourceId(R.styleable.SherlockMenuItem_android_icon, 0);
+            itemLegacyIconResId = a.getResourceId(R.styleable.SherlockMenuItem_legacyIcon, 0);
             itemAlphabeticShortcut =
                     getShortcut(a.getString(R.styleable.SherlockMenuItem_android_alphabeticShortcut));
             itemNumericShortcut =
@@ -417,6 +419,7 @@ public class MenuInflater {
                 .setCheckable(itemCheckable >= 1)
                 .setTitleCondensed(itemTitleCondensed)
                 .setIcon(itemIconResId)
+                .setLegacyIcon(itemLegacyIconResId)
                 .setAlphabeticShortcut(itemAlphabeticShortcut)
                 .setNumericShortcut(itemNumericShortcut);
 

--- a/actionbarsherlock/src/com/actionbarsherlock/view/MenuItem.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/view/MenuItem.java
@@ -223,6 +223,10 @@ public interface MenuItem {
      */
     public Drawable getIcon();
 
+    public MenuItem setLegacyIcon(Drawable icon);
+    public MenuItem setLegacyIcon(int iconRes);
+    public Drawable getLegacyIcon();
+
     /**
      * Change the Intent associated with this item.  By default there is no
      * Intent associated with a menu item.  If you set one, and nothing


### PR DESCRIPTION
Action icons that work well in a dark action bar usually don't work well
in the legacy menu of Android 2.x. This patch allows to specify a
second icon that will be used in the legacy menu.

Example:
<menu xmlns:android="http://schemas.android.com/apk/res/android"
      xmlns:app="http://schemas.android.com/apk/res-auto" >
<item
  android:id="@+id/add"
  android:icon="@drawable/ic_action_add"
  app:legacyIcon="@drawable/ic_menu_add"
  android:title="@string/add" />
</menu>
