### PR TITLE
Close IcsSpinner DropDown programmatically

### DIFF
--- a/library/src/com/actionbarsherlock/internal/widget/IcsSpinner.java
+++ b/library/src/com/actionbarsherlock/internal/widget/IcsSpinner.java
@@ -167,6 +167,12 @@ public class IcsSpinner extends IcsAbsSpinner implements OnClickListener {
         }
     }
 
+    public void closeSpinnerPopup() {
+        if ((mPopup != null) && mPopup.isShowing()) {
+            mPopup.dismiss();
+        }
+    }
+
     @Override
     public void setAdapter(SpinnerAdapter adapter) {
         super.setAdapter(adapter);


### PR DESCRIPTION
Hi,

 I am using a IcsSpinner within a SlidingMenu in my app. The problem is if I open the IcsSpinner's popup and than close the SlidingMenu programmatically the popup will not be dismissed. I am not sure if this is the best way to solve it but i wrote a little quickfix by providing a method in the IcsSpinner to close the popup programmatically.
