### PR TITLE
Fix static import which throws off Scala builds

### DIFF
--- a/library/src/com/actionbarsherlock/app/SherlockFragment.java
+++ b/library/src/com/actionbarsherlock/app/SherlockFragment.java
@@ -8,9 +8,9 @@ import com.actionbarsherlock.view.Menu;
 import com.actionbarsherlock.view.MenuInflater;
 import com.actionbarsherlock.view.MenuItem;
 
-import static com.actionbarsherlock.app.SherlockFragmentActivity.OnCreateOptionsMenuListener;
-import static com.actionbarsherlock.app.SherlockFragmentActivity.OnOptionsItemSelectedListener;
-import static com.actionbarsherlock.app.SherlockFragmentActivity.OnPrepareOptionsMenuListener;
+import static android.support.v4.app.Watson.OnCreateOptionsMenuListener;
+import static android.support.v4.app.Watson.OnOptionsItemSelectedListener;
+import static android.support.v4.app.Watson.OnPrepareOptionsMenuListener;
 
 public class SherlockFragment extends Fragment implements OnCreateOptionsMenuListener, OnPrepareOptionsMenuListener, OnOptionsItemSelectedListener {
     private SherlockFragmentActivity mActivity;


### PR DESCRIPTION
For some reason sbt with android-plugin is not able to deal with these static imports.

The error itself is:

```
... SherlockFragment.java:11: value OnCreateOptionsMenuListener is not a member of object com.actionbarsherlock.app.SherlockFragmentActivity
[error] import static com.actionbarsherlock.app.SherlockFragmentActivity.OnCreateOptionsMenuListener;
```

Importing them from Watson.java fixes the problem.
