### PR TITLE
Navigation spinner doesn't properly scroll to the currently selected item if there are many items in the list

### DIFF
--- a/actionbarsherlock-samples/known-bugs/AndroidManifest.xml
+++ b/actionbarsherlock-samples/known-bugs/AndroidManifest.xml
@@ -44,7 +44,13 @@
                 <category android:name="com.actionbarsherlock.sample.knownbugs.OPEN"/>
             </intent-filter>
         </activity>
-
+        
+        <activity android:label="Issue #882" android:name=".Issue882">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="com.actionbarsherlock.sample.knownbugs.OPEN"/>
+            </intent-filter>
+        </activity>
 
         <!-- CLOSED BUGS -->
 

--- a/actionbarsherlock-samples/known-bugs/res/layout/issue882.xml
+++ b/actionbarsherlock-samples/known-bugs/res/layout/issue882.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:orientation="vertical"
+        android:padding="5dp"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    <android.support.v4.view.ViewPager
+            android:id="@+id/pager"
+            android:layout_width="match_parent"
+            android:layout_height="0px"
+            android:layout_weight="1"/>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="5dp"
+        android:text="In collapsed mode, select Fragment 10 from the spinner.  Tap the spinner again to display the choices.  On native, Fragment 10 is shown on the list, on ABS, Fragment 1 is shown instead."/>
+
+</LinearLayout>

--- a/actionbarsherlock-samples/known-bugs/src/com/actionbarsherlock/sample/knownbugs/Issue882.java
+++ b/actionbarsherlock-samples/known-bugs/src/com/actionbarsherlock/sample/knownbugs/Issue882.java
@@ -1,0 +1,131 @@
+package com.actionbarsherlock.sample.knownbugs;
+
+import static android.view.Gravity.CENTER;
+import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
+import static com.actionbarsherlock.app.ActionBar.NAVIGATION_MODE_TABS;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentStatePagerAdapter;
+import android.support.v4.app.FragmentTransaction;
+import android.support.v4.view.ViewPager;
+import android.support.v4.view.ViewPager.OnPageChangeListener;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import com.actionbarsherlock.app.ActionBar;
+import com.actionbarsherlock.app.ActionBar.TabListener;
+import com.actionbarsherlock.app.SherlockFragment;
+import com.actionbarsherlock.app.SherlockFragmentActivity;
+
+public class Issue882 extends SherlockFragmentActivity implements
+		OnPageChangeListener, TabListener {
+	private static final int COUNT = 20;
+
+	ViewPager mPager;
+
+	@Override
+	protected void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		setContentView(R.layout.issue882);
+
+		mPager = (ViewPager) findViewById(R.id.pager);
+		mPager.setAdapter(new MyAdapter(getSupportFragmentManager()));
+		mPager.setOnPageChangeListener(this);
+
+		ActionBar ab = getSupportActionBar();
+		ab.setNavigationMode(NAVIGATION_MODE_TABS);
+		for (int i = 1; i <= COUNT; i++) {
+			ab.addTab(ab.newTab().setText("Fragment " + i).setTabListener(this));
+		}
+	}
+
+	@Override
+	public void onPageScrolled(int position, float positionOffset,
+			int positionOffsetPixels) {
+	}
+
+	@Override
+	public void onPageSelected(int position) {
+		getSupportActionBar().setSelectedNavigationItem(position);
+	}
+
+	@Override
+	public void onPageScrollStateChanged(int state) {
+	}
+
+	@Override
+	public void onTabSelected(ActionBar.Tab tab, FragmentTransaction ft) {
+		mPager.setCurrentItem(tab.getPosition());
+	}
+
+	@Override
+	public void onTabUnselected(ActionBar.Tab tab, FragmentTransaction ft) {
+	}
+
+	@Override
+	public void onTabReselected(ActionBar.Tab tab, FragmentTransaction ft) {
+	}
+
+	public static class MyAdapter extends FragmentStatePagerAdapter {
+		public MyAdapter(FragmentManager fm) {
+			super(fm);
+		}
+
+		@Override
+		public int getCount() {
+			return COUNT;
+		}
+
+		@Override
+		public Fragment getItem(int position) {
+			return BoringFragment.newInstance(position + 1);
+		}
+	}
+
+	public static class BoringFragment extends SherlockFragment {
+		int mNum;
+
+		/**
+		 * Create a new instance of CountingFragment, providing "num" as an
+		 * argument.
+		 */
+		static BoringFragment newInstance(int num) {
+			BoringFragment f = new BoringFragment();
+
+			// Supply num input as an argument.
+			Bundle args = new Bundle();
+			args.putInt("num", num);
+			f.setArguments(args);
+
+			return f;
+		}
+
+		/**
+		 * When creating, retrieve this instance's number from its arguments.
+		 */
+		@Override
+		public void onCreate(Bundle savedInstanceState) {
+			super.onCreate(savedInstanceState);
+			mNum = getArguments() != null ? getArguments().getInt("num") : 1;
+		}
+
+		/**
+		 * The Fragment's UI is just a simple text view showing its instance
+		 * number.
+		 */
+		@Override
+		public View onCreateView(LayoutInflater inflater, ViewGroup container,
+				Bundle savedInstanceState) {
+			TextView tv = new TextView(getActivity());
+			tv.setLayoutParams(new ViewGroup.LayoutParams(MATCH_PARENT,
+					MATCH_PARENT));
+			tv.setText("Fragment #" + mNum);
+			tv.setGravity(CENTER);
+			return tv;
+		}
+
+	}
+}


### PR DESCRIPTION
This demonstrates the ABS bug due to the missing setSelection() method in IcsListPopupWindow
