### PR TITLE
Fix for NullPointerException while importing into Eclipse

### DIFF
--- a/actionbarsherlock/pom.xml
+++ b/actionbarsherlock/pom.xml
@@ -110,6 +110,7 @@
         <plugin>
           <groupId>org.eclipse.m2e</groupId>
           <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
           <configuration>
             <lifecycleMappingMetadata>
               <pluginExecutions>


### PR DESCRIPTION
While importing the new version (4.3.0), I get a NullPointerException because he cannot guess the version for the lifecycle-plugin.
In the old version, there was also a version given (https://github.com/JakeWharton/ActionBarSherlock/blob/4.2.0/library/pom.xml#L124)
