### PR TITLE
Removed final from methods that ought to be overridable.

### DIFF
--- a/actionbarsherlock/src/com/actionbarsherlock/app/SherlockActivity.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/app/SherlockActivity.java
@@ -95,7 +95,7 @@ public abstract class SherlockActivity extends Activity implements OnCreatePanel
     }
 
     @Override
-    public final boolean onMenuOpened(int featureId, android.view.Menu menu) {
+    public boolean onMenuOpened(int featureId, android.view.Menu menu) {
         if (getSherlock().dispatchMenuOpened(featureId, menu)) {
             return true;
         }
@@ -145,17 +145,17 @@ public abstract class SherlockActivity extends Activity implements OnCreatePanel
     }
 
     @Override
-    public final boolean onCreateOptionsMenu(android.view.Menu menu) {
+    public boolean onCreateOptionsMenu(android.view.Menu menu) {
         return getSherlock().dispatchCreateOptionsMenu(menu);
     }
 
     @Override
-    public final boolean onPrepareOptionsMenu(android.view.Menu menu) {
+    public boolean onPrepareOptionsMenu(android.view.Menu menu) {
         return getSherlock().dispatchPrepareOptionsMenu(menu);
     }
 
     @Override
-    public final boolean onOptionsItemSelected(android.view.MenuItem item) {
+    public boolean onOptionsItemSelected(android.view.MenuItem item) {
         return getSherlock().dispatchOptionsItemSelected(item);
     }
 

--- a/actionbarsherlock/src/com/actionbarsherlock/app/SherlockDialogFragment.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/app/SherlockDialogFragment.java
@@ -36,7 +36,7 @@ public class SherlockDialogFragment extends DialogFragment implements OnCreateOp
     }
 
     @Override
-    public final void onCreateOptionsMenu(android.view.Menu menu, android.view.MenuInflater inflater) {
+    public void onCreateOptionsMenu(android.view.Menu menu, android.view.MenuInflater inflater) {
         onCreateOptionsMenu(new MenuWrapper(menu), mActivity.getSupportMenuInflater());
     }
 
@@ -56,7 +56,7 @@ public class SherlockDialogFragment extends DialogFragment implements OnCreateOp
     }
 
     @Override
-    public final boolean onOptionsItemSelected(android.view.MenuItem item) {
+    public boolean onOptionsItemSelected(android.view.MenuItem item) {
         return onOptionsItemSelected(new MenuItemWrapper(item));
     }
 

--- a/actionbarsherlock/src/com/actionbarsherlock/app/SherlockExpandableListActivity.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/app/SherlockExpandableListActivity.java
@@ -95,7 +95,7 @@ public abstract class SherlockExpandableListActivity extends ExpandableListActiv
     }
 
     @Override
-    public final boolean onMenuOpened(int featureId, android.view.Menu menu) {
+    public boolean onMenuOpened(int featureId, android.view.Menu menu) {
         if (getSherlock().dispatchMenuOpened(featureId, menu)) {
             return true;
         }
@@ -134,17 +134,17 @@ public abstract class SherlockExpandableListActivity extends ExpandableListActiv
     }
 
     @Override
-    public final boolean onCreateOptionsMenu(android.view.Menu menu) {
+    public boolean onCreateOptionsMenu(android.view.Menu menu) {
         return getSherlock().dispatchCreateOptionsMenu(menu);
     }
 
     @Override
-    public final boolean onPrepareOptionsMenu(android.view.Menu menu) {
+    public boolean onPrepareOptionsMenu(android.view.Menu menu) {
         return getSherlock().dispatchPrepareOptionsMenu(menu);
     }
 
     @Override
-    public final boolean onOptionsItemSelected(android.view.MenuItem item) {
+    public boolean onOptionsItemSelected(android.view.MenuItem item) {
         return getSherlock().dispatchOptionsItemSelected(item);
     }
 

--- a/actionbarsherlock/src/com/actionbarsherlock/app/SherlockFragment.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/app/SherlockFragment.java
@@ -36,7 +36,7 @@ public class SherlockFragment extends Fragment implements OnCreateOptionsMenuLis
     }
 
     @Override
-    public final void onCreateOptionsMenu(android.view.Menu menu, android.view.MenuInflater inflater) {
+    public void onCreateOptionsMenu(android.view.Menu menu, android.view.MenuInflater inflater) {
         onCreateOptionsMenu(new MenuWrapper(menu), mActivity.getSupportMenuInflater());
     }
 
@@ -46,7 +46,7 @@ public class SherlockFragment extends Fragment implements OnCreateOptionsMenuLis
     }
 
     @Override
-    public final void onPrepareOptionsMenu(android.view.Menu menu) {
+    public void onPrepareOptionsMenu(android.view.Menu menu) {
         onPrepareOptionsMenu(new MenuWrapper(menu));
     }
 
@@ -56,7 +56,7 @@ public class SherlockFragment extends Fragment implements OnCreateOptionsMenuLis
     }
 
     @Override
-    public final boolean onOptionsItemSelected(android.view.MenuItem item) {
+    public boolean onOptionsItemSelected(android.view.MenuItem item) {
         return onOptionsItemSelected(new MenuItemWrapper(item));
     }
 

--- a/actionbarsherlock/src/com/actionbarsherlock/app/SherlockFragmentActivity.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/app/SherlockFragmentActivity.java
@@ -101,7 +101,7 @@ public class SherlockFragmentActivity extends Watson implements OnActionModeStar
     }
 
     @Override
-    public final boolean onMenuOpened(int featureId, android.view.Menu menu) {
+    public boolean onMenuOpened(int featureId, android.view.Menu menu) {
         if (getSherlock().dispatchMenuOpened(featureId, menu)) {
             return true;
         }
@@ -157,7 +157,7 @@ public class SherlockFragmentActivity extends Watson implements OnActionModeStar
     }
 
     @Override
-    public final boolean onCreatePanelMenu(int featureId, android.view.Menu menu) {
+    public boolean onCreatePanelMenu(int featureId, android.view.Menu menu) {
         if (BuildConfig.DEBUG) Log.d(TAG, "[onCreatePanelMenu] featureId: " + featureId + ", menu: " + menu);
 
         if (featureId == Window.FEATURE_OPTIONS_PANEL && !mIgnoreNativeCreate) {
@@ -172,12 +172,12 @@ public class SherlockFragmentActivity extends Watson implements OnActionModeStar
     }
 
     @Override
-    public final boolean onCreateOptionsMenu(android.view.Menu menu) {
+    public boolean onCreateOptionsMenu(android.view.Menu menu) {
         return true;
     }
 
     @Override
-    public final boolean onPreparePanel(int featureId, View view, android.view.Menu menu) {
+    public boolean onPreparePanel(int featureId, View view, android.view.Menu menu) {
         if (BuildConfig.DEBUG) Log.d(TAG, "[onPreparePanel] featureId: " + featureId + ", view: " + view + ", menu: " + menu);
 
         if (featureId == Window.FEATURE_OPTIONS_PANEL && !mIgnoreNativePrepare) {
@@ -192,12 +192,12 @@ public class SherlockFragmentActivity extends Watson implements OnActionModeStar
     }
 
     @Override
-    public final boolean onPrepareOptionsMenu(android.view.Menu menu) {
+    public boolean onPrepareOptionsMenu(android.view.Menu menu) {
         return true;
     }
 
     @Override
-    public final boolean onMenuItemSelected(int featureId, android.view.MenuItem item) {
+    public boolean onMenuItemSelected(int featureId, android.view.MenuItem item) {
         if (BuildConfig.DEBUG) Log.d(TAG, "[onMenuItemSelected] featureId: " + featureId + ", item: " + item);
 
         if (featureId == Window.FEATURE_OPTIONS_PANEL && !mIgnoreNativeSelected) {
@@ -212,7 +212,7 @@ public class SherlockFragmentActivity extends Watson implements OnActionModeStar
     }
 
     @Override
-    public final boolean onOptionsItemSelected(android.view.MenuItem item) {
+    public boolean onOptionsItemSelected(android.view.MenuItem item) {
         return false;
     }
 

--- a/actionbarsherlock/src/com/actionbarsherlock/app/SherlockListActivity.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/app/SherlockListActivity.java
@@ -95,7 +95,7 @@ public abstract class SherlockListActivity extends ListActivity implements OnCre
     }
 
     @Override
-    public final boolean onMenuOpened(int featureId, android.view.Menu menu) {
+    public boolean onMenuOpened(int featureId, android.view.Menu menu) {
         if (getSherlock().dispatchMenuOpened(featureId, menu)) {
             return true;
         }
@@ -145,17 +145,17 @@ public abstract class SherlockListActivity extends ListActivity implements OnCre
     }
 
     @Override
-    public final boolean onCreateOptionsMenu(android.view.Menu menu) {
+    public boolean onCreateOptionsMenu(android.view.Menu menu) {
         return getSherlock().dispatchCreateOptionsMenu(menu);
     }
 
     @Override
-    public final boolean onPrepareOptionsMenu(android.view.Menu menu) {
+    public boolean onPrepareOptionsMenu(android.view.Menu menu) {
         return getSherlock().dispatchPrepareOptionsMenu(menu);
     }
 
     @Override
-    public final boolean onOptionsItemSelected(android.view.MenuItem item) {
+    public boolean onOptionsItemSelected(android.view.MenuItem item) {
         return getSherlock().dispatchOptionsItemSelected(item);
     }
 

--- a/actionbarsherlock/src/com/actionbarsherlock/app/SherlockListFragment.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/app/SherlockListFragment.java
@@ -36,7 +36,7 @@ public class SherlockListFragment extends ListFragment implements OnCreateOption
     }
 
     @Override
-    public final void onCreateOptionsMenu(android.view.Menu menu, android.view.MenuInflater inflater) {
+    public void onCreateOptionsMenu(android.view.Menu menu, android.view.MenuInflater inflater) {
         onCreateOptionsMenu(new MenuWrapper(menu), mActivity.getSupportMenuInflater());
     }
 
@@ -46,7 +46,7 @@ public class SherlockListFragment extends ListFragment implements OnCreateOption
     }
 
     @Override
-    public final void onPrepareOptionsMenu(android.view.Menu menu) {
+    public void onPrepareOptionsMenu(android.view.Menu menu) {
         onPrepareOptionsMenu(new MenuWrapper(menu));
     }
 
@@ -56,7 +56,7 @@ public class SherlockListFragment extends ListFragment implements OnCreateOption
     }
 
     @Override
-    public final boolean onOptionsItemSelected(android.view.MenuItem item) {
+    public boolean onOptionsItemSelected(android.view.MenuItem item) {
         return onOptionsItemSelected(new MenuItemWrapper(item));
     }
 

--- a/actionbarsherlock/src/com/actionbarsherlock/app/SherlockPreferenceActivity.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/app/SherlockPreferenceActivity.java
@@ -95,7 +95,7 @@ public abstract class SherlockPreferenceActivity extends PreferenceActivity impl
     }
 
     @Override
-    public final boolean onMenuOpened(int featureId, android.view.Menu menu) {
+    public boolean onMenuOpened(int featureId, android.view.Menu menu) {
         if (getSherlock().dispatchMenuOpened(featureId, menu)) {
             return true;
         }
@@ -145,17 +145,17 @@ public abstract class SherlockPreferenceActivity extends PreferenceActivity impl
     }
 
     @Override
-    public final boolean onCreateOptionsMenu(android.view.Menu menu) {
+    public boolean onCreateOptionsMenu(android.view.Menu menu) {
         return getSherlock().dispatchCreateOptionsMenu(menu);
     }
 
     @Override
-    public final boolean onPrepareOptionsMenu(android.view.Menu menu) {
+    public boolean onPrepareOptionsMenu(android.view.Menu menu) {
         return getSherlock().dispatchPrepareOptionsMenu(menu);
     }
 
     @Override
-    public final boolean onOptionsItemSelected(android.view.MenuItem item) {
+    public boolean onOptionsItemSelected(android.view.MenuItem item) {
         return getSherlock().dispatchOptionsItemSelected(item);
     }
 


### PR DESCRIPTION
You declare certain methods in ListActivity and ListFragment that are originally overridable as final. This breaks some applications that rely on overriding these methods.
