### PR TITLE
Fixed a warning with Maven regarding mismatched SDK target values

### DIFF
--- a/actionbarsherlock/project.properties
+++ b/actionbarsherlock/project.properties
@@ -9,4 +9,4 @@
 
 android.library=true
 # Project target.
-target=android-14
+target=android-16


### PR DESCRIPTION
The target value in project.properties did not match that declared in AndroidManifest.xml, giving this warning with Maven in IntelliJ IDEA:

> Error when importing module '~apklib-com.actionbarsherlock_actionbarsherlock_4.3.0': Cannot find appropriate Android platform for API level 14

I realize this is happening because I don't have the files for API 14 installed, but this is still inconsistent with the target SDK value in the manifest of 16. Updating the value to android-16 stops this warning.
