### PR TITLE
fix NullPointerException when trying to select invalid tab position

### DIFF
--- a/library/src/com/actionbarsherlock/internal/widget/ScrollingTabContainerView.java
+++ b/library/src/com/actionbarsherlock/internal/widget/ScrollingTabContainerView.java
@@ -241,17 +241,19 @@ public class ScrollingTabContainerView extends NineHorizontalScrollView
 
     public void animateToTab(final int position) {
         final View tabView = mTabLayout.getChildAt(position);
-        if (mTabSelector != null) {
-            removeCallbacks(mTabSelector);
+        if (tabView!=null){
+        	if (mTabSelector != null) {
+        		removeCallbacks(mTabSelector);
+        	}
+        	mTabSelector = new Runnable() {
+        		public void run() {
+        			final int scrollPos = tabView.getLeft() - (getWidth() - tabView.getWidth()) / 2;
+        			smoothScrollTo(scrollPos, 0);
+        			mTabSelector = null;
+        		}
+        	};
+        	post(mTabSelector);
         }
-        mTabSelector = new Runnable() {
-            public void run() {
-                final int scrollPos = tabView.getLeft() - (getWidth() - tabView.getWidth()) / 2;
-                smoothScrollTo(scrollPos, 0);
-                mTabSelector = null;
-            }
-        };
-        post(mTabSelector);
     }
 
     @Override


### PR DESCRIPTION
Self explanatory, the library should not make the application crash even if application select an invalid tab position
