### PR TITLE
Improve handling of popup menus and expose PopupMenu

### DIFF
--- a/actionbarsherlock/src/com/actionbarsherlock/internal/widget/IcsListPopupWindow.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/internal/widget/IcsListPopupWindow.java
@@ -36,7 +36,7 @@ public class IcsListPopupWindow {
     private static final int EXPAND_LIST_TIMEOUT = 250;
 
     private Context mContext;
-    private PopupWindow mPopup;
+    private final PopupWindowCompat mPopup;
     private ListAdapter mAdapter;
     private DropDownListView mDropDownList;
 
@@ -80,7 +80,7 @@ public class IcsListPopupWindow {
 
     public IcsListPopupWindow(Context context, AttributeSet attrs, int defStyleAttr) {
         mContext = context;
-        mPopup = new PopupWindow(context, attrs, defStyleAttr);
+        mPopup = new PopupWindowCompat(context, attrs, defStyleAttr);
         mPopup.setInputMethodMode(PopupWindow.INPUT_METHOD_NEEDED);
     }
 
@@ -88,9 +88,9 @@ public class IcsListPopupWindow {
         mContext = context;
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
             Context wrapped = new ContextThemeWrapper(context, defStyleRes);
-            mPopup = new PopupWindow(wrapped, attrs, defStyleAttr);
+            mPopup = new PopupWindowCompat(wrapped, attrs, defStyleAttr);
         } else {
-            mPopup = new PopupWindow(context, attrs, defStyleAttr, defStyleRes);
+            mPopup = new PopupWindowCompat(context, attrs, defStyleAttr, defStyleRes);
         }
         mPopup.setInputMethodMode(PopupWindow.INPUT_METHOD_NEEDED);
     }

--- a/actionbarsherlock/src/com/actionbarsherlock/internal/widget/PopupWindowCompat.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/internal/widget/PopupWindowCompat.java
@@ -1,0 +1,178 @@
+
+package com.actionbarsherlock.internal.widget;
+
+import java.lang.reflect.Field;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewTreeObserver;
+import android.view.ViewTreeObserver.OnScrollChangedListener;
+import android.widget.PopupWindow;
+
+/**
+ * Works around bugs in the handling of {@link ViewTreeObserver} by
+ * {@link PopupWindow}.
+ * <p>
+ * <code>PopupWindow</code> registers an {@link OnScrollChangedListener} with
+ * {@link ViewTreeObserver}, but does not keep a reference to the observer
+ * instance that it has registers on. This is problematic when the anchor view
+ * used by <code>PopupWindow</code> to access the observer is detached from the
+ * window, as it will revert from the shared <code>ViewTreeObserver</code> owned
+ * by the <code>ViewRoot</code> to a floating one, meaning
+ * <code>PopupWindow</code> cannot unregister it's listener anymore and has
+ * leaked it into the global observer.
+ * <p>
+ * This class works around this issue by
+ * <ul>
+ * <li>replacing <code>PopupWindow.mOnScrollChangedListener</code> with a no-op
+ * listener so that any registration or unregistration performed by
+ * <code>PopupWindow</code> itself has no effect and causes no leaks.
+ * <li>registering the real listener only with the shared
+ * <code>ViewTreeObserver</code> and keeping a reference to it to facilitate
+ * correct unregistration. The reason for not registering on a floating observer
+ * (before a view is attached) is that there is no safe way to get a reference
+ * to the shared observer that the floating one will be merged into. This would
+ * again cause the listener to leak.
+ * </ul>
+ */
+public class PopupWindowCompat extends PopupWindow {
+
+    private static final Field superListenerField;
+    static {
+        Field f = null;
+        try {
+            f = PopupWindow.class.getDeclaredField("mOnScrollChangedListener");
+            f.setAccessible(true);
+        } catch (NoSuchFieldException e) {
+            /* ignored */
+        }
+        superListenerField = f;
+    }
+
+    private static final OnScrollChangedListener NOP = new OnScrollChangedListener() {
+        @Override
+        public void onScrollChanged() {
+            /* do nothing */
+        }
+    };
+
+    private OnScrollChangedListener mSuperScrollListener;
+    private ViewTreeObserver mViewTreeObserver;
+
+    public PopupWindowCompat() {
+        super();
+        init();
+    }
+
+    public PopupWindowCompat(Context context) {
+        super(context);
+        init();
+    }
+
+    public PopupWindowCompat(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public PopupWindowCompat(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+        init();
+    }
+
+    // @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    public PopupWindowCompat(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        init();
+    }
+
+    public PopupWindowCompat(int width, int height) {
+        super(width, height);
+        init();
+    }
+
+    public PopupWindowCompat(View contentView) {
+        super(contentView);
+        init();
+    }
+
+    public PopupWindowCompat(View contentView, int width, int height, boolean focusable) {
+        super(contentView, width, height, focusable);
+        init();
+    }
+
+    public PopupWindowCompat(View contentView, int width, int height) {
+        super(contentView, width, height);
+        init();
+    }
+
+    private void init() {
+        if (superListenerField != null) {
+            try {
+                mSuperScrollListener = (OnScrollChangedListener) superListenerField.get(this);
+                superListenerField.set(this, NOP);
+            } catch (Exception e) {
+                mSuperScrollListener = null;
+            }
+        }
+    }
+
+    private void unregisterListener() {
+        // Don't do anything if we haven't managed to patch the super listener
+        if (mSuperScrollListener != null && mViewTreeObserver != null) {
+            if (mViewTreeObserver.isAlive()) {
+                mViewTreeObserver.removeOnScrollChangedListener(mSuperScrollListener);
+            }
+            mViewTreeObserver = null;
+        }
+    }
+
+    private void registerListener(View anchor) {
+        // Don't do anything if we haven't managed to patch the super listener.
+        // And don't bother attaching the listener if the anchor view isn't
+        // attached. This means we'll only have to deal with the real VTO owned
+        // by the ViewRoot.
+        if (mSuperScrollListener != null) {
+            ViewTreeObserver vto = (anchor.getWindowToken() != null) ? anchor.getViewTreeObserver()
+                    : null;
+            if (vto != mViewTreeObserver) {
+                if (mViewTreeObserver != null && mViewTreeObserver.isAlive()) {
+                    mViewTreeObserver.removeOnScrollChangedListener(mSuperScrollListener);
+                }
+                if ((mViewTreeObserver = vto) != null) {
+                    vto.addOnScrollChangedListener(mSuperScrollListener);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void showAsDropDown(View anchor, int xoff, int yoff) {
+        super.showAsDropDown(anchor, xoff, yoff);
+        registerListener(anchor);
+    }
+
+    @Override
+    public void update(View anchor, int xoff, int yoff, int width, int height) {
+        super.update(anchor, xoff, yoff, width, height);
+        registerListener(anchor);
+    }
+
+    @Override
+    public void update(View anchor, int width, int height) {
+        super.update(anchor, width, height);
+        registerListener(anchor);
+    }
+
+    @Override
+    public void showAtLocation(View parent, int gravity, int x, int y) {
+        super.showAtLocation(parent, gravity, x, y);
+        unregisterListener();
+    }
+
+    @Override
+    public void dismiss() {
+        super.dismiss();
+        unregisterListener();
+    }
+}

--- a/actionbarsherlock/src/com/actionbarsherlock/widget/PopupMenu.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/widget/PopupMenu.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.actionbarsherlock.widget;
+
+import android.content.Context;
+import android.view.View;
+
+import com.actionbarsherlock.internal.view.menu.MenuBuilder;
+import com.actionbarsherlock.internal.view.menu.MenuPopupHelper;
+import com.actionbarsherlock.internal.view.menu.MenuPresenter;
+import com.actionbarsherlock.internal.view.menu.SubMenuBuilder;
+import com.actionbarsherlock.view.Menu;
+import com.actionbarsherlock.view.MenuInflater;
+import com.actionbarsherlock.view.MenuItem;
+
+
+/**
+ * A PopupMenu displays a {@link Menu} in a modal popup window anchored to a {@link View}.
+ * The popup will appear below the anchor view if there is room, or above it if there is not.
+ * If the IME is visible the popup will not overlap it until it is touched. Touching outside
+ * of the popup will dismiss it.
+ */
+public class PopupMenu implements MenuBuilder.Callback, MenuPresenter.Callback {
+    private Context mContext;
+    private MenuBuilder mMenu;
+    private View mAnchor;
+    private MenuPopupHelper mPopup;
+    private OnMenuItemClickListener mMenuItemClickListener;
+    private OnDismissListener mDismissListener;
+
+    /**
+     * Callback interface used to notify the application that the menu has closed.
+     */
+    public interface OnDismissListener {
+        /**
+         * Called when the associated menu has been dismissed.
+         *
+         * @param menu The PopupMenu that was dismissed.
+         */
+        public void onDismiss(PopupMenu menu);
+    }
+
+    /**
+     * Construct a new PopupMenu.
+     *
+     * @param context Context for the PopupMenu.
+     * @param anchor Anchor view for this popup. The popup will appear below the anchor if there
+     *               is room, or above it if there is not.
+     */
+    public PopupMenu(Context context, View anchor) {
+        // TODO Theme?
+        mContext = context;
+        mMenu = new MenuBuilder(context);
+        mMenu.setCallback(this);
+        mAnchor = anchor;
+        mPopup = new MenuPopupHelper(context, mMenu, anchor);
+        mPopup.setCallback(this);
+    }
+
+    /**
+     * @return the {@link Menu} associated with this popup. Populate the returned Menu with
+     * items before calling {@link #show()}.
+     *
+     * @see #show()
+     * @see #getMenuInflater()
+     */
+    public Menu getMenu() {
+        return mMenu;
+    }
+
+    /**
+     * @return a {@link MenuInflater} that can be used to inflate menu items from XML into the
+     * menu returned by {@link #getMenu()}.
+     *
+     * @see #getMenu()
+     */
+    public MenuInflater getMenuInflater() {
+        return new MenuInflater(mContext);
+    }
+
+    /**
+     * Inflate a menu resource into this PopupMenu. This is equivalent to calling
+     * popupMenu.getMenuInflater().inflate(menuRes, popupMenu.getMenu()).
+     * @param menuRes Menu resource to inflate
+     */
+    public void inflate(int menuRes) {
+        getMenuInflater().inflate(menuRes, mMenu);
+    }
+
+    /**
+     * Show the menu popup anchored to the view specified during construction.
+     * @see #dismiss()
+     */
+    public void show() {
+        mPopup.show();
+    }
+
+    /**
+     * Dismiss the menu popup.
+     * @see #show()
+     */
+    public void dismiss() {
+        mPopup.dismiss();
+    }
+
+    /**
+     * Set a listener that will be notified when the user selects an item from the menu.
+     *
+     * @param listener Listener to notify
+     */
+    public void setOnMenuItemClickListener(OnMenuItemClickListener listener) {
+        mMenuItemClickListener = listener;
+    }
+
+    /**
+     * Set a listener that will be notified when this menu is dismissed.
+     *
+     * @param listener Listener to notify
+     */
+    public void setOnDismissListener(OnDismissListener listener) {
+        mDismissListener = listener;
+    }
+
+    /**
+     * @hide
+     */
+    public boolean onMenuItemSelected(MenuBuilder menu, MenuItem item) {
+        if (mMenuItemClickListener != null) {
+            return mMenuItemClickListener.onMenuItemClick(item);
+        }
+        return false;
+    }
+
+    /**
+     * @hide
+     */
+    public void onCloseMenu(MenuBuilder menu, boolean allMenusAreClosing) {
+        if (mDismissListener != null) {
+            mDismissListener.onDismiss(this);
+        }
+    }
+
+    /**
+     * @hide
+     */
+    public boolean onOpenSubMenu(MenuBuilder subMenu) {
+        // AOSP code creates another MenuPopupHelper(), but MenuPopupHelper.onSubMenuSelected() already does.
+        return false;
+    }
+
+    /**
+     * @hide
+     */
+    public void onCloseSubMenu(SubMenuBuilder menu) {
+    }
+
+    /**
+     * @hide
+     */
+    public void onMenuModeChange(MenuBuilder menu) {
+    }
+
+    /**
+     * Interface responsible for receiving menu item click events if the items themselves
+     * do not have individual item click listeners.
+     */
+    public interface OnMenuItemClickListener {
+        /**
+         * This method will be invoked when a menu item is clicked if the item itself did
+         * not already handle the event.
+         *
+         * @param item {@link MenuItem} that was clicked
+         * @return <code>true</code> if the event was handled, <code>false</code> otherwise.
+         */
+        public boolean onMenuItemClick(MenuItem item);
+    }
+}


### PR DESCRIPTION
This should fix #752.
- Work around PopupWindow's leaking of listeners into the ViewRoot VTO
  when the anchor view is detached before the popup is dismissed.
- Apply similar changes to MenuPopupHelper. This also means that support for
  OnAttachStateChangeListener is not required for correct operation of the
  popup window anymore. OnAttachStateChangeListener is still used in case
  the popup anchor view is not attached when the popup is shown, even though
  this seems unlikely to happen in practice as positioning of the popup is
  pretty meaningless in that case. It would be possible to remove the entire
  OnAttachStateChangeListener shim as a second step.
- Included PopupMenu from AOSP. I'm aware this has been previously declined as a feature request as technically it's not part of the ActionBar, However, ABS uses popup menus internally and all the plumbing and resources are already in place, so adding this single class to actually expose what's already there saves a lot of duplication and hassle.
