### PR TITLE
update android build tools to 0.5.+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:0.4.+'
+    classpath 'com.android.tools.build:gradle:0.5.+'
   }
 }
 
@@ -20,5 +20,7 @@ allprojects {
     options.encoding = "UTF-8"
   }
 }
+
+task assemble{}
 
 apply plugin: 'android-reporting'

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,4 @@ allprojects {
   }
 }
 
-task assemble{}
-
 apply plugin: 'android-reporting'


### PR DESCRIPTION
Android Gradle plug-in 0.5.0. This new version of the plug-in is not backwards compatible. When opening a project that uses an older version of the plug-in, Studio will show the following error as a balloon in the upper right corner of the IDE:

You will need to change the version of the Android Gradle plug-in to 0.5.0. Just click the link “Search in build.gradle files” to look for the places where this change needs to be made. (See the Troubleshooting section below for more info).
