### PR TITLE
make performItemAction compatible with ActionProvider sub menu

### DIFF
--- a/actionbarsherlock/src/com/actionbarsherlock/internal/view/menu/MenuBuilder.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/internal/view/menu/MenuBuilder.java
@@ -884,19 +884,26 @@ public class MenuBuilder implements Menu {
 
         boolean invoked = itemImpl.invoke();
 
+        final ActionProvider provider = item.getActionProvider();
+        final boolean providerHasSubMenu = provider != null && provider.hasSubMenu();
         if (itemImpl.hasCollapsibleActionView()) {
             invoked |= itemImpl.expandActionView();
-            if (invoked) close(true);
-        } else if (item.hasSubMenu()) {
+            if (invoked)
+                close(true);
+        } else if (itemImpl.hasSubMenu() || providerHasSubMenu) {
             close(false);
 
-            final SubMenuBuilder subMenu = (SubMenuBuilder) item.getSubMenu();
-            final ActionProvider provider = item.getActionProvider();
-            if (provider != null && provider.hasSubMenu()) {
+            if (!itemImpl.hasSubMenu()) {
+                itemImpl.setSubMenu(new SubMenuBuilder(getContext(), this, itemImpl));
+            }
+
+            final SubMenuBuilder subMenu = (SubMenuBuilder) itemImpl.getSubMenu();
+            if (providerHasSubMenu) {
                 provider.onPrepareSubMenu(subMenu);
             }
             invoked |= dispatchSubMenuSelected(subMenu);
-            if (!invoked) close(true);
+            if (!invoked)
+                close(true);
         } else {
             if ((flags & FLAG_PERFORM_NO_CLOSE) == 0) {
                 close(true);


### PR DESCRIPTION
In the case of the submenu of an ActionItem is provided by an ActionProvider and not directly by the ActionItem, the submenu was not displayed onClick. 

It was working with native implementation and not with ActionBarSherlock one. 

I've backport the method from Android code source to have the correct implementation.
