### PR TITLE
Fix cell usage calculation for menu items with text

### DIFF
--- a/actionbarsherlock/src/com/actionbarsherlock/internal/view/menu/ActionMenuView.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/internal/view/menu/ActionMenuView.java
@@ -353,8 +353,12 @@ public class ActionMenuView extends IcsLinearLayout implements MenuBuilder.ItemI
         final int childHeightMode = MeasureSpec.getMode(parentHeightMeasureSpec);
         final int childHeightSpec = MeasureSpec.makeMeasureSpec(childHeightSize, childHeightMode);
 
+        final ActionMenuItemView itemView = child instanceof ActionMenuItemView ?
+                (ActionMenuItemView) child : null;
+        final boolean hasText = itemView != null && itemView.hasText();
+
         int cellsUsed = 0;
-        if (cellsRemaining > 0) {
+        if (cellsRemaining > 0 && (!hasText || cellsRemaining >= 2)) {
             final int childWidthSpec = MeasureSpec.makeMeasureSpec(
                     cellSize * cellsRemaining, MeasureSpec.AT_MOST);
             child.measure(childWidthSpec, childHeightSpec);
@@ -364,8 +368,6 @@ public class ActionMenuView extends IcsLinearLayout implements MenuBuilder.ItemI
             if (measuredWidth % cellSize != 0) cellsUsed++;
         }
 
-        final ActionMenuItemView itemView = child instanceof ActionMenuItemView ?
-                (ActionMenuItemView) child : null;
         final boolean expandable = !lp.isOverflowButton && itemView != null && itemView.hasText();
         lp.expandable = expandable;
 


### PR DESCRIPTION
This prevents an edge case where menu items with text have 1 available cell and end up using it, thus overlapping the overflow button.

This is based on Android 4.2.2's code for ActionMenuView: http://grepcode.com/file/repository.grepcode.com/java/ext/com.google.android/android/4.2.2_r1/com/android/internal/view/menu/ActionMenuView.java#ActionMenuView.measureChildForCells%28android.view.View%2Cint%2Cint%2Cint%2Cint%29
