### PR TITLE
Fix issue #652 NPE on all sdks

### DIFF
--- a/actionbarsherlock/src/com/actionbarsherlock/internal/view/menu/MenuBuilder.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/internal/view/menu/MenuBuilder.java
@@ -354,8 +354,8 @@ public class MenuBuilder implements Menu {
         SparseArray<Parcelable> viewStates = states.getSparseParcelableArray(
                 getActionViewStatesKey());
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB && viewStates == null) {
-            //Fixes Issue #652 with sdk <= 2.3.6
+        if (viewStates == null) {
+            //Fixes Issue #652 for all sdks
             return;
         }
 


### PR DESCRIPTION
Calling dispatchRestoreInstanceState from ABS causes View.java to throw a NPE. This bug was appearing on devices running 3.1, 3.2, and 3.2.1

View.java doesn't check for a null container in dispatchRestoreInstanceState so we need to check it here.
