### PR TITLE
Implement a left margin on the home icon

### DIFF
--- a/actionbarsherlock/res/layout/abs__action_bar_home.xml
+++ b/actionbarsherlock/res/layout/abs__action_bar_home.xml
@@ -29,6 +29,7 @@
     <ImageView android:id="@id/abs__home"
                android:layout_width="wrap_content"
                android:layout_height="wrap_content"
+               android:layout_marginLeft="@dimen/abs__action_bar_icon_left_margin"
                android:layout_marginRight="8dip"
                android:layout_marginTop="@dimen/abs__action_bar_icon_vertical_padding"
                android:layout_marginBottom="@dimen/abs__action_bar_icon_vertical_padding"

--- a/actionbarsherlock/res/values/abs__dimens.xml
+++ b/actionbarsherlock/res/values/abs__dimens.xml
@@ -52,4 +52,7 @@
 
     <!-- Preferred width of the search view. -->
     <dimen name="abs__search_view_preferred_width">320dip</dimen>
+    
+    <!-- Default margin of the home icon. -->
+    <dimen name="abs__action_bar_icon_left_margin">0dip</dimen>
 </resources>


### PR DESCRIPTION
Trying to solve the use case where the action bar up is not enabled but the home icon is centered. Generally this requires creating a custom home layout and overriding (otherwise the left margin isn't quite right), but this allows that margin to be overriden by using a custom style like this:

```
<?xml version="1.0" encoding="utf-8"?>
<resources>
    <style name="Theme.Styled" parent="Theme.Sherlock.Light.DarkActionBar">
        <item name="actionBarStyle">@style/Widget.Styled.ActionBar</item>
        <item name="android:actionBarStyle">@style/Widget.Styled.ActionBar</item>
        <item name="homeAsUpIndicator">@null</item>
        <item name="android:homeAsUpIndicator">@null</item>
    </style>

    <style name="Widget.Styled.ActionBar" parent="Widget.Sherlock.Light.ActionBar.Solid.Inverse">
        <item name="homeAsUpIndicator">@null</item>
        <item name="android:homeAsUpIndicator">@null</item>
    </style>

    <dimen name="abs__action_bar_icon_left_margin">12dip</dimen>
</resources>
```
