### PR TITLE
Fix activity leak.

### DIFF
--- a/actionbarsherlock/src/com/actionbarsherlock/internal/widget/ActionBarView.java
+++ b/actionbarsherlock/src/com/actionbarsherlock/internal/widget/ActionBarView.java
@@ -217,6 +217,7 @@ public class ActionBarView extends AbsActionBarView {
             if (mIcon == null) {
                 mIcon = appInfo.loadIcon(pm);
             }
+            mIcon = mIcon.getConstantState().newDrawable();
         }
 
         final LayoutInflater inflater = LayoutInflater.from(context);


### PR DESCRIPTION
The leak is found in HomeView.mIconView.mCallback.mContext  
Turns out when we call in ActionBarView:212      

```
 mIcon = pm.getActivityIcon(((Activity) context).getComponentName());                                             
```

the system returns the same Icon,  
So the ImageView from second started activity sets its callback and it prevents the activity to be garbage collected
The leak is reproducible in 2.3.6  
On the later versions of sdk type of Drawable.mCallback changed from Callback to WeakReference<Callback> so it cant be reproduced on newer sdk versions                                        

Steps to reproduce:  
1. start activity1  
2. start activity2  
3. finish activity2  
4. activity2 will remain in memory                         

There is a demonstration of the leak https://github.com/kurganec/ActionBarSherlock/tree/activity_leak in known_bugs project
