### PR TITLE
Probably fix intermittent irreproducible NPE

### DIFF
--- a/library/src/com/actionbarsherlock/internal/view/menu/MenuBuilder.java
+++ b/library/src/com/actionbarsherlock/internal/view/menu/MenuBuilder.java
@@ -353,6 +353,10 @@ public class MenuBuilder implements Menu {
         SparseArray<Parcelable> viewStates = states.getSparseParcelableArray(
                 getActionViewStatesKey());
 
+        if (viewStates == null) {
+            return; // NPE from View.restoreHierarchyState, dispatchRestoreInstanceState:6473.
+        }
+
         final int itemCount = size();
         for (int i = 0; i < itemCount; i++) {
             final MenuItem item = getItem(i);


### PR DESCRIPTION
We're seeing this NPE in all OS versions from 2.3 to 4.3 (the vast majority in 2.3.6), ultimately ending up in View.dispatchRestoreInstanceState. 'container' seems to be the only object invoked with a method in the versions of dispatchRestoreInstanceState() I've examined.

Caused by: java.lang.NullPointerException
1    android.view.View.dispatchRestoreInstanceState  View.java, line 6473
2    android.view.ViewGroup.dispatchRestoreInstanceState     ViewGroup.java, line 1211
3    android.view.View.restoreHierarchyState     View.java, line 6457
4    com.actionbarsherlock.internal.view.menu.MenuBuilder.restoreActionViewStates    SourceFile, line 361
5    com.actionbarsherlock.internal.ActionBarSherlockCompat.preparePanel     SourceFile, line 503
6    com.actionbarsherlock.internal.ActionBarSherlockCompat.dispatchInvalidateOptionsMenu    SourceFile, line 272
7    com.actionbarsherlock.app.SherlockFragmentActivity.invalidateOptionsMenu    SourceFile, line 150
8    com.actionbarsherlock.app.SherlockFragmentActivity.supportInvalidateOptionsMenu     SourceFile, line 156
