### PR TITLE
build.gradle: Bump com.android.tools.build.gradle to 0.6+

### DIFF
--- a/actionbarsherlock/build.gradle
+++ b/actionbarsherlock/build.gradle
@@ -15,4 +15,9 @@ android {
       res.srcDirs = ['res']
     }
   }
+
+  lintOptions {
+      abortOnError false
+  }
+
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:0.5.+'
+    classpath 'com.android.tools.build:gradle:0.6.+'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:0.6.+'
+    classpath 'com.android.tools.build:gradle:0.7.+'
   }
 }
 


### PR DESCRIPTION
Android Studio 0.3.7 complains for me that the Android Gradle Plugin needs to be 0.6.3 or greater. This PR changes the gradle plugin from 0.5.+ to 0.6.+
