### PR TITLE
Add support for Android Studio 0.5.0+

### DIFF
--- a/actionbarsherlock-fest/build.gradle
+++ b/actionbarsherlock-fest/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
 android {
   compileSdkVersion 14
-  buildToolsVersion '17.0.0'
+  buildToolsVersion '19.0.0'
 
   sourceSets {
     main {

--- a/actionbarsherlock-i18n/build.gradle
+++ b/actionbarsherlock-i18n/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
 android {
   compileSdkVersion 14
-  buildToolsVersion '17.0.0'
+  buildToolsVersion '19.0.0'
 
   sourceSets {
     main {

--- a/actionbarsherlock/build.gradle
+++ b/actionbarsherlock/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
 android {
   compileSdkVersion 14
-  buildToolsVersion '17.0.0'
+  buildToolsVersion '19.0.0'
 
   sourceSets {
     main {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:0.5.+'
+    classpath 'com.android.tools.build:gradle:0.9.+'
   }
 }
 


### PR DESCRIPTION
- Update build.gradle to specify Gradle 0.9+
- Update build.gradle files to specify build tools 19.0.0+
